### PR TITLE
feat: add admin-configurable transaction fees per accepted token

### DIFF
--- a/contracts/shade/src/errors.rs
+++ b/contracts/shade/src/errors.rs
@@ -15,4 +15,5 @@ pub enum ContractError {
     ContractPaused = 9,
     ContractNotPaused = 10,
     MerchantKeyNotFound = 11,
+    TokenNotAccepted = 12,
 }

--- a/contracts/shade/src/events.rs
+++ b/contracts/shade/src/events.rs
@@ -175,6 +175,22 @@ pub fn publish_contract_unpaused_event(env: &Env, admin: Address, timestamp: u64
 }
 
 #[contractevent]
+pub struct FeeSetEvent {
+    pub token: Address,
+    pub fee: i128,
+    pub timestamp: u64,
+}
+
+pub fn publish_fee_set_event(env: &Env, token: Address, fee: i128, timestamp: u64) {
+    FeeSetEvent {
+        token,
+        fee,
+        timestamp,
+    }
+    .publish(env);
+}
+
+#[contractevent]
 pub struct ContractUpgradedEvent {
     pub new_wasm_hash: BytesN<32>,
     pub timestamp: u64,

--- a/contracts/shade/src/interface.rs
+++ b/contracts/shade/src/interface.rs
@@ -8,6 +8,8 @@ pub trait ShadeTrait {
     fn add_accepted_token(env: Env, admin: Address, token: Address);
     fn remove_accepted_token(env: Env, admin: Address, token: Address);
     fn is_accepted_token(env: Env, token: Address) -> bool;
+    fn set_fee(env: Env, admin: Address, token: Address, fee: i128);
+    fn get_fee(env: Env, token: Address) -> i128;
     fn register_merchant(env: Env, merchant: Address);
     fn get_merchant(env: Env, merchant_id: u64) -> Merchant;
     fn get_merchants(env: Env, filter: MerchantFilter) -> Vec<Merchant>;

--- a/contracts/shade/src/shade.rs
+++ b/contracts/shade/src/shade.rs
@@ -46,6 +46,15 @@ impl ShadeTrait for Shade {
         admin_component::is_accepted_token(&env, &token)
     }
 
+    fn set_fee(env: Env, admin: Address, token: Address, fee: i128) {
+        pausable_component::assert_not_paused(&env);
+        admin_component::set_fee(&env, &admin, &token, fee);
+    }
+
+    fn get_fee(env: Env, token: Address) -> i128 {
+        admin_component::get_fee(&env, &token)
+    }
+
     fn register_merchant(env: Env, merchant: Address) {
         pausable_component::assert_not_paused(&env);
         merchant_component::register_merchant(&env, &merchant);

--- a/contracts/shade/src/types.rs
+++ b/contracts/shade/src/types.rs
@@ -12,6 +12,7 @@ pub enum DataKey {
     MerchantKey(Address),
     MerchantCount,
     MerchantId(Address),
+    TokenFee(Address),
     MerchantTokens,
     MerchantBalance(Address),
     Invoice(u64),


### PR DESCRIPTION
CLOSES #34

## Description

Implement admin-configurable transaction fees per accepted token. This allows the protocol to earn revenue from transactions by letting the admin set fee amounts for each token on the accepted tokens list.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [ ] Test improvements
- [ ] Other (please describe):

## Related Issues

Fixes #

## Changes Made

- Added `TokenFee(Address)` variant to `DataKey` enum in `types.rs` for per-token fee storage
- Added `TokenNotAccepted = 12` error variant to `ContractError` in `errors.rs`
- Added `FeeSetEvent` struct and `publish_fee_set_event` helper in `events.rs`
- Implemented `set_fee` in `components/admin.rs` — admin-only, reentrancy-guarded, validates the token is on the accepted list before saving the fee
- Implemented `get_fee` in `components/admin.rs` — returns the stored fee for a token, defaulting to `0` if unset
- Extended `ShadeTrait` in `interface.rs` with `set_fee` and `get_fee` method signatures
- Wired up `set_fee` (with pause guard) and `get_fee` in `shade.rs`

## Testing

- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass locally
- [ ] I have tested this manually

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

- `set_fee` enforces that only accepted tokens can have fees configured, panicking with `TokenNotAccepted` otherwise
- `set_fee` is blocked when the contract is paused, consistent with other admin write operations
- Reentrancy protection is applied to `set_fee` following the same pattern as `add_accepted_token` and `remove_accepted_token`
- `get_fee` is a read-only query and does not require pause or reentrancy checks