### PR TITLE
feat: add admin-configurable transaction fees per accepted token

### DIFF
--- a/contracts/shade/src/tests/mod.rs
+++ b/contracts/shade/src/tests/mod.rs
@@ -1,5 +1,6 @@
 pub mod test;
 pub mod test_accepted_tokens;
+pub mod test_fees;
 pub mod test_invoice;
 pub mod test_merchant_key;
 pub mod test_merchant_verification;

--- a/contracts/shade/src/tests/test_fees.rs
+++ b/contracts/shade/src/tests/test_fees.rs
@@ -1,0 +1,129 @@
+#![cfg(test)]
+
+use crate::components::admin as admin_component;
+use crate::errors::ContractError;
+use crate::shade::Shade;
+use crate::shade::ShadeClient;
+use soroban_sdk::testutils::{Address as _, Events as _};
+use soroban_sdk::{Address, Env, Map, Symbol, TryIntoVal, Val};
+
+fn setup_with_accepted_token(env: &Env) -> (Address, ShadeClient<'_>, Address) {
+    env.mock_all_auths();
+
+    let contract_id = env.register(Shade, ());
+    let client = ShadeClient::new(env, &contract_id);
+
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+
+    client.add_accepted_token(&admin, &token);
+
+    (admin, client, token)
+}
+
+fn assert_fee_set_event(
+    env: &Env,
+    contract_id: &Address,
+    expected_token: &Address,
+    expected_fee: i128,
+    expected_timestamp: u64,
+) {
+    let events = env.events().all();
+    assert!(events.len() > 0);
+
+    let (event_contract_id, topics, data) = events.get(events.len() - 1).unwrap();
+    assert_eq!(event_contract_id, contract_id.clone());
+    assert_eq!(topics.len(), 1);
+
+    let event_name: Symbol = topics.get(0).unwrap().try_into_val(env).unwrap();
+    assert_eq!(event_name, Symbol::new(env, "fee_set_event"));
+
+    let data_map: Map<Symbol, Val> = data.try_into_val(env).unwrap();
+    let token_val = data_map.get(Symbol::new(env, "token")).unwrap();
+    let fee_val = data_map.get(Symbol::new(env, "fee")).unwrap();
+    let timestamp_val = data_map.get(Symbol::new(env, "timestamp")).unwrap();
+
+    let token_in_event: Address = token_val.try_into_val(env).unwrap();
+    let fee_in_event: i128 = fee_val.try_into_val(env).unwrap();
+    let timestamp_in_event: u64 = timestamp_val.try_into_val(env).unwrap();
+
+    assert_eq!(token_in_event, expected_token.clone());
+    assert_eq!(fee_in_event, expected_fee);
+    assert_eq!(timestamp_in_event, expected_timestamp);
+}
+
+#[test]
+fn test_set_fee_success() {
+    let env = Env::default();
+    let (admin, client, token) = setup_with_accepted_token(&env);
+    let contract_id = client.address.clone();
+    let fee: i128 = 500;
+
+    let expected_timestamp = env.ledger().timestamp();
+
+    env.as_contract(&contract_id, || {
+        admin_component::set_fee(&env, &admin, &token, fee);
+        assert_fee_set_event(&env, &contract_id, &token, fee, expected_timestamp);
+    });
+
+    assert_eq!(client.get_fee(&token), fee);
+}
+
+#[test]
+fn test_set_fee_unaccepted_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(Shade, ());
+    let client = ShadeClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let unaccepted_token = Address::generate(&env);
+
+    let expected_error =
+        soroban_sdk::Error::from_contract_error(ContractError::TokenNotAccepted as u32);
+
+    let result = client.try_set_fee(&admin, &unaccepted_token, &100);
+    assert!(matches!(result, Err(Ok(err)) if err == expected_error));
+}
+
+#[test]
+fn test_set_fee_unauthorized() {
+    let env = Env::default();
+    let (_admin, client, token) = setup_with_accepted_token(&env);
+
+    let non_admin = Address::generate(&env);
+
+    let expected_error =
+        soroban_sdk::Error::from_contract_error(ContractError::NotAuthorized as u32);
+
+    let result = client.try_set_fee(&non_admin, &token, &100);
+    assert!(matches!(result, Err(Ok(err)) if err == expected_error));
+}
+
+#[test]
+fn test_update_fee() {
+    let env = Env::default();
+    let (admin, client, token) = setup_with_accepted_token(&env);
+
+    client.set_fee(&admin, &token, &200);
+    assert_eq!(client.get_fee(&token), 200);
+
+    client.set_fee(&admin, &token, &750);
+    assert_eq!(client.get_fee(&token), 750);
+}
+
+#[test]
+fn test_get_fee_default_zero() {
+    let env = Env::default();
+    let (_admin, client, token) = setup_with_accepted_token(&env);
+
+    assert_eq!(client.get_fee(&token), 0);
+}


### PR DESCRIPTION
CLOSES #35


## Description

Add comprehensive tests to verify the fee management functionality, ensuring admins can set fees for accepted tokens and that the contract enforces all validation rules (authorization, token acceptance, storage correctness, and event emission).

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Code refactoring
- [x] Test improvements
- [ ] Other (please describe):

## Related Issues

Fixes #

## Changes Made

- Added new test file `contracts/shade/src/tests/test_fees.rs` with 5 test cases covering the full fee management surface area.
- Registered `test_fees` module in `contracts/shade/src/tests/mod.rs`.

## Testing

| Test | Scenario |
|---|---|
| `test_set_fee_success` | Admin adds an accepted token, sets a fee, verifies `get_fee` returns the correct amount, and asserts `FeeSetEvent` is emitted with correct token, fee, and timestamp. |
| `test_set_fee_unaccepted_token` | Attempts to set a fee for a token not in the accepted list and asserts the `TokenNotAccepted` contract error is returned. |
| `test_set_fee_unauthorized` | A non-admin address attempts to set a fee and asserts the `NotAuthorized` contract error is returned. |
| `test_update_fee` | Sets a fee to 200, updates it to 750, and verifies `get_fee` reflects the latest value. |
| `test_get_fee_default_zero` | Verifies `get_fee` returns `0` for an accepted token with no fee explicitly set. |

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass locally
- [ ] I have tested this manually

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published

## Screenshots (if applicable)

N/A

## Additional Notes

Tests validate all three acceptance criteria: admin-only access enforcement, accepted-token validation, and correct storage/retrieval of fee values. The test structure follows the same patterns established in `test_accepted_tokens.rs`, using `env.as_contract` for event assertions and `try_*` client methods for error-path tests.