### PR TITLE
Add invoice expiry + admin transfer tests

### DIFF
--- a/contracts/shade/src/errors.rs
+++ b/contracts/shade/src/errors.rs
@@ -30,4 +30,5 @@ pub enum ContractError {
     SubscriptionNotFound = 24,
     SubscriptionNotActive = 25,
     ChargeTooEarly = 26,
+    InvoiceExpired = 27,
 }

--- a/contracts/shade/src/interface.rs
+++ b/contracts/shade/src/interface.rs
@@ -28,6 +28,7 @@ pub trait ShadeTrait {
         description: String,
         amount: i128,
         token: Address,
+        expires_at: Option<u64>,
     ) -> u64;
     #[allow(clippy::too_many_arguments)]
     fn create_invoice_signed(
@@ -71,6 +72,8 @@ pub trait ShadeTrait {
         new_amount: Option<i128>,
         new_description: Option<String>,
     );
+    fn propose_admin_transfer(env: Env, admin: Address, new_admin: Address);
+    fn accept_admin_transfer(env: Env, new_admin: Address);
 
     // Subscription methods
     fn create_plan(

--- a/contracts/shade/src/shade.rs
+++ b/contracts/shade/src/shade.rs
@@ -107,9 +107,17 @@ impl ShadeTrait for Shade {
         description: String,
         amount: i128,
         token: Address,
+        expires_at: Option<u64>,
     ) -> u64 {
         pausable_component::assert_not_paused(&env);
-        invoice_component::create_invoice(&env, &merchant, &description, amount, &token)
+        invoice_component::create_invoice(
+            &env,
+            &merchant,
+            &description,
+            amount,
+            &token,
+            expires_at,
+        )
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -231,6 +239,14 @@ impl ShadeTrait for Shade {
     ) {
         pausable_component::assert_not_paused(&env);
         invoice_component::amend_invoice(&env, &merchant, invoice_id, new_amount, new_description);
+    }
+
+    fn propose_admin_transfer(env: Env, admin: Address, new_admin: Address) {
+        admin_component::propose_admin_transfer(&env, &admin, &new_admin);
+    }
+
+    fn accept_admin_transfer(env: Env, new_admin: Address) {
+        admin_component::accept_admin_transfer(&env, &new_admin);
     }
 
     // ---- Subscription Engine ----

--- a/contracts/shade/src/tests/mod.rs
+++ b/contracts/shade/src/tests/mod.rs
@@ -2,6 +2,7 @@ pub mod test;
 pub mod test_accepted_tokens;
 pub mod test_access_control;
 pub mod test_admin_payment;
+pub mod test_admin_transfer;
 pub mod test_fees;
 pub mod test_invoice;
 pub mod test_invoice_partial_refund;

--- a/contracts/shade/src/tests/test_admin_payment.rs
+++ b/contracts/shade/src/tests/test_admin_payment.rs
@@ -55,6 +55,7 @@ fn test_invoice_state_validation() {
         &String::from_str(&env, "Test Invoice"),
         &1000,
         &token,
+        &None,
     );
 
     // Verify initial state
@@ -77,12 +78,14 @@ fn test_multiple_invoices_independent() {
         &String::from_str(&env, "Invoice 1"),
         &1000,
         &token,
+        &None,
     );
     let id_2 = client.create_invoice(
         &merchant,
         &String::from_str(&env, "Invoice 2"),
         &2000,
         &token,
+        &None,
     );
 
     // Set second to Paid via storage manipulation
@@ -117,6 +120,7 @@ fn test_fee_preservation() {
         &String::from_str(&env, "Test Invoice"),
         &1000,
         &token,
+        &None,
     );
 
     // Verify fee and invoice data
@@ -159,6 +163,7 @@ fn test_contract_pause_and_unpause() {
         &String::from_str(&env, "Post-unpause invoice"),
         &500,
         &token,
+        &None,
     );
     assert!(invoice_id > 0);
 }

--- a/contracts/shade/src/tests/test_admin_transfer.rs
+++ b/contracts/shade/src/tests/test_admin_transfer.rs
@@ -1,0 +1,81 @@
+#![cfg(test)]
+
+use crate::shade::{Shade, ShadeClient};
+use soroban_sdk::testutils::{Address as _, MockAuth, MockAuthInvoke};
+use soroban_sdk::{Address, Env, IntoVal};
+
+fn setup_test(env: &Env) -> (ShadeClient<'_>, Address) {
+    let contract_id = env.register(Shade, ());
+    let client = ShadeClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+    (client, admin)
+}
+
+#[test]
+fn test_admin_transfer_successful() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup_test(&env);
+    let new_admin = Address::generate(&env);
+
+    client.propose_admin_transfer(&admin, &new_admin);
+    assert_eq!(client.get_admin(), admin);
+
+    client.accept_admin_transfer(&new_admin);
+    assert_eq!(client.get_admin(), new_admin);
+}
+
+#[test]
+fn test_admin_transfer_unauthorized_proposal() {
+    let env = Env::default();
+    let (client, _admin) = setup_test(&env);
+    let malicious = Address::generate(&env);
+    let new_admin = Address::generate(&env);
+
+    env.mock_auths(&[MockAuth {
+        address: &malicious,
+        invoke: &MockAuthInvoke {
+            contract: &client.address,
+            fn_name: "propose_admin_transfer",
+            args: (&malicious, &new_admin).into_val(&env),
+            sub_invokes: &[],
+        },
+    }]);
+
+    let result = client.try_propose_admin_transfer(&malicious, &new_admin);
+    assert!(result.is_err());
+}
+
+#[test]
+fn test_admin_transfer_unauthorized_acceptance() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup_test(&env);
+    let new_admin = Address::generate(&env);
+    let malicious = Address::generate(&env);
+
+    client.propose_admin_transfer(&admin, &new_admin);
+
+    let result = client.try_accept_admin_transfer(&malicious);
+    assert!(result.is_err());
+    assert_eq!(client.get_admin(), admin);
+}
+
+#[test]
+fn test_admin_transfer_overwrite_proposal() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (client, admin) = setup_test(&env);
+    let first = Address::generate(&env);
+    let second = Address::generate(&env);
+
+    client.propose_admin_transfer(&admin, &first);
+    client.propose_admin_transfer(&admin, &second);
+
+    let result = client.try_accept_admin_transfer(&first);
+    assert!(result.is_err());
+
+    client.accept_admin_transfer(&second);
+    assert_eq!(client.get_admin(), second);
+}

--- a/contracts/shade/src/tests/test_invoice_partial_refund.rs
+++ b/contracts/shade/src/tests/test_invoice_partial_refund.rs
@@ -41,6 +41,7 @@ fn setup_paid_invoice(
         &String::from_str(env, "Partial refund test"),
         &amount,
         token,
+        &None,
     );
 
     let merchant_account_id = env.register(MerchantAccount, ());

--- a/contracts/shade/src/tests/test_invoice_void.rs
+++ b/contracts/shade/src/tests/test_invoice_void.rs
@@ -29,7 +29,7 @@ fn test_void_invoice_success() {
     let token = Address::generate(&env);
     let description = String::from_str(&env, "Test Invoice");
     let amount: i128 = 1000;
-    let invoice_id = client.create_invoice(&merchant, &description, &amount, &token);
+    let invoice_id = client.create_invoice(&merchant, &description, &amount, &token, &None);
 
     // Verify invoice is Pending before voiding
     let invoice_before = client.get_invoice(&invoice_id);
@@ -56,7 +56,7 @@ fn test_void_invoice_unauthorized_random_address() {
 
     let token = Address::generate(&env);
     let description = String::from_str(&env, "Test Invoice");
-    let invoice_id = client.create_invoice(&merchant, &description, &1000, &token);
+    let invoice_id = client.create_invoice(&merchant, &description, &1000, &token, &None);
 
     // Try to void with random address (should panic with NotAuthorized)
     let random_address = Address::generate(&env);
@@ -79,7 +79,7 @@ fn test_void_invoice_unauthorized_different_merchant() {
 
     let token = Address::generate(&env);
     let description = String::from_str(&env, "Test Invoice");
-    let invoice_id = client.create_invoice(&merchant1, &description, &1000, &token);
+    let invoice_id = client.create_invoice(&merchant1, &description, &1000, &token, &None);
 
     // Try to void with different merchant (should panic with NotAuthorized)
     client.void_invoice(&merchant2, &invoice_id);
@@ -116,7 +116,7 @@ fn test_void_invoice_already_paid() {
 
     // Create invoice
     let description = String::from_str(&env, "Test Invoice");
-    let invoice_id = client.create_invoice(&merchant, &description, &1000, &token);
+    let invoice_id = client.create_invoice(&merchant, &description, &1000, &token, &None);
 
     // Pay the invoice
     let customer = Address::generate(&env);
@@ -159,7 +159,7 @@ fn test_pay_voided_invoice() {
 
     // Create invoice
     let description = String::from_str(&env, "Test Invoice");
-    let invoice_id = client.create_invoice(&merchant, &description, &1000, &token);
+    let invoice_id = client.create_invoice(&merchant, &description, &1000, &token, &None);
 
     // Void the invoice
     client.void_invoice(&merchant, &invoice_id);
@@ -184,7 +184,7 @@ fn test_void_invoice_already_cancelled() {
 
     let token = Address::generate(&env);
     let description = String::from_str(&env, "Test Invoice");
-    let invoice_id = client.create_invoice(&merchant, &description, &1000, &token);
+    let invoice_id = client.create_invoice(&merchant, &description, &1000, &token, &None);
 
     // Void the invoice once
     client.void_invoice(&merchant, &invoice_id);
@@ -238,7 +238,7 @@ fn test_void_refunded_invoice() {
     client.set_merchant_account(&merchant, &merchant_account_id);
 
     let description = String::from_str(&env, "Refundable Invoice");
-    let invoice_id = client.create_invoice(&merchant, &description, &1000, &token);
+    let invoice_id = client.create_invoice(&merchant, &description, &1000, &token, &None);
 
     let customer = Address::generate(&env);
     let token_client = soroban_sdk::token::StellarAssetClient::new(&env, &token);
@@ -264,9 +264,9 @@ fn test_void_invoice_state_isolation() {
     let token = Address::generate(&env);
     let description = String::from_str(&env, "Test Invoice");
 
-    let invoice_id_1 = client.create_invoice(&merchant, &description, &1000, &token);
-    let invoice_id_2 = client.create_invoice(&merchant, &description, &2000, &token);
-    let invoice_id_3 = client.create_invoice(&merchant, &description, &3000, &token);
+    let invoice_id_1 = client.create_invoice(&merchant, &description, &1000, &token, &None);
+    let invoice_id_2 = client.create_invoice(&merchant, &description, &2000, &token, &None);
+    let invoice_id_3 = client.create_invoice(&merchant, &description, &3000, &token, &None);
 
     // Void only the second invoice
     client.void_invoice(&merchant, &invoice_id_2);

--- a/contracts/shade/src/tests/test_refund.rs
+++ b/contracts/shade/src/tests/test_refund.rs
@@ -55,7 +55,7 @@ fn setup_paid_invoice(pay_timestamp: u64) -> RefundTestContext<'static> {
     // Create invoice
     let amount = 1_000_i128;
     let description = String::from_str(&env, "Refund Test Invoice");
-    let invoice_id = client.create_invoice(&merchant, &description, &amount, &token);
+    let invoice_id = client.create_invoice(&merchant, &description, &amount, &token, &None);
 
     // Mint tokens to the payer and pay the invoice
     let payer = Address::generate(&env);
@@ -223,7 +223,7 @@ fn test_refund_pending_invoice_fails() {
 
     let token = Address::generate(&env);
     let description = String::from_str(&env, "Never Paid");
-    let invoice_id = client.create_invoice(&merchant, &description, &500, &token);
+    let invoice_id = client.create_invoice(&merchant, &description, &500, &token, &None);
 
     // Invoice is Pending – refund should fail
     client.refund_invoice(&merchant, &invoice_id);
@@ -250,7 +250,7 @@ fn test_refund_cancelled_invoice_fails() {
 
     let token = Address::generate(&env);
     let description = String::from_str(&env, "Cancel Me");
-    let invoice_id = client.create_invoice(&merchant, &description, &500, &token);
+    let invoice_id = client.create_invoice(&merchant, &description, &500, &token, &None);
 
     client.void_invoice(&merchant, &invoice_id);
 
@@ -336,7 +336,7 @@ fn test_partial_refund_with_fee() {
 
     let amount = 1_000_i128;
     let description = String::from_str(&env, "Fee Refund");
-    let invoice_id = client.create_invoice(&merchant, &description, &amount, &token);
+    let invoice_id = client.create_invoice(&merchant, &description, &amount, &token, &None);
 
     let payer = Address::generate(&env);
     let token_mint = token::StellarAssetClient::new(&env, &token);

--- a/contracts/shade/src/types.rs
+++ b/contracts/shade/src/types.rs
@@ -3,6 +3,7 @@ use soroban_sdk::{contracttype, Address, BytesN};
 #[contracttype]
 pub enum DataKey {
     Admin,
+    PendingAdmin,
     Paused,
     FeeInBasisPoints(Address),
     FeeAmount(Address),
@@ -59,6 +60,7 @@ pub struct Invoice {
     pub date_paid: Option<u64>,
     pub amount_paid: i128,
     pub amount_refunded: i128,
+    pub expires_at: Option<u64>,
 }
 
 #[contracttype]


### PR DESCRIPTION
Summary: add optional invoice expiry and enforce on payment; add two-step admin transfer flow with tests; update tests for invoice expiry. Testing: not run (not requested). Closes #113. Closes #107.