### PR TITLE
Feat/implement merchant defined accepted token list

### DIFF
--- a/contracts/shade/src/components/merchant.rs
+++ b/contracts/shade/src/components/merchant.rs
@@ -312,21 +312,78 @@ pub fn set_merchant_accepted_tokens(env: &Env, merchant: &Address, tokens: &Vec<
         panic_with_error!(env, ContractError::MerchantNotFound);
     }
 
-    // Verify all tokens are globally accepted
+    let merchant_id = get_merchant_id(env, merchant);
+    if !is_merchant_active(env, merchant_id) {
+        panic_with_error!(env, ContractError::MerchantNotActive);
+    }
+
+    // Deduplicate and verify all tokens are globally accepted
+    let mut deduped: Vec<Address> = Vec::new(env);
     for token in tokens.iter() {
         if !admin_component::is_accepted_token(env, &token) {
             panic_with_error!(env, ContractError::TokenNotAccepted);
+        }
+        // Only add if not already present
+        let mut found = false;
+        for existing in deduped.iter() {
+            if existing == token {
+                found = true;
+                break;
+            }
+        }
+        if !found {
+            deduped.push_back(token.clone());
         }
     }
 
     env.storage()
         .persistent()
-        .set(&DataKey::MerchantTokens(merchant.clone()), tokens);
+        .set(&DataKey::MerchantTokens(merchant.clone()), &deduped);
 
     events::publish_merchant_tokens_set_event(
         env,
         merchant.clone(),
-        tokens.clone(),
+        deduped,
+        env.ledger().timestamp(),
+    );
+}
+
+pub fn remove_merchant_accepted_token(env: &Env, merchant: &Address, token: &Address) {
+    merchant.require_auth();
+
+    if !is_merchant(env, merchant) {
+        panic_with_error!(env, ContractError::MerchantNotFound);
+    }
+
+    let merchant_id = get_merchant_id(env, merchant);
+    if !is_merchant_active(env, merchant_id) {
+        panic_with_error!(env, ContractError::MerchantNotActive);
+    }
+
+    let merchant_tokens = get_merchant_accepted_tokens(env, merchant);
+    let mut updated: Vec<Address> = Vec::new(env);
+    let mut found = false;
+
+    for t in merchant_tokens.iter() {
+        if t == *token {
+            found = true;
+        } else {
+            updated.push_back(t);
+        }
+    }
+
+    if !found {
+        panic_with_error!(env, ContractError::TokenNotAccepted);
+    }
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::MerchantTokens(merchant.clone()), &updated);
+
+    events::publish_merchant_token_removed_event(
+        env,
+        merchant.clone(),
+        token.clone(),
         env.ledger().timestamp(),
     );
 }

--- a/contracts/shade/src/events.rs
+++ b/contracts/shade/src/events.rs
@@ -616,3 +616,24 @@ pub fn publish_merchant_tokens_set_event(
     }
     .publish(env);
 }
+
+#[contractevent]
+pub struct MerchantTokenRemovedEvent {
+    pub merchant: Address,
+    pub token: Address,
+    pub timestamp: u64,
+}
+
+pub fn publish_merchant_token_removed_event(
+    env: &Env,
+    merchant: Address,
+    token: Address,
+    timestamp: u64,
+) {
+    MerchantTokenRemovedEvent {
+        merchant,
+        token,
+        timestamp,
+    }
+    .publish(env);
+}

--- a/contracts/shade/src/interface.rs
+++ b/contracts/shade/src/interface.rs
@@ -84,6 +84,8 @@ pub trait ShadeTrait {
 
     fn set_merchant_accepted_tokens(env: Env, merchant: Address, tokens: Vec<Address>);
     fn get_merchant_accepted_tokens(env: Env, merchant: Address) -> Vec<Address>;
+    fn remove_merchant_accepted_token(env: Env, merchant: Address, token: Address);
+    fn is_token_accepted_for_merchant(env: Env, merchant: Address, token: Address) -> bool;
 
     // ── Admin transfer (two-step handover) ───────────────────────────────────
 

--- a/contracts/shade/src/shade.rs
+++ b/contracts/shade/src/shade.rs
@@ -318,4 +318,13 @@ impl ShadeTrait for Shade {
     fn get_merchant_accepted_tokens(env: Env, merchant: Address) -> Vec<Address> {
         merchant_component::get_merchant_accepted_tokens(&env, &merchant)
     }
+
+    fn remove_merchant_accepted_token(env: Env, merchant: Address, token: Address) {
+        pausable_component::assert_not_paused(&env);
+        merchant_component::remove_merchant_accepted_token(&env, &merchant, &token);
+    }
+
+    fn is_token_accepted_for_merchant(env: Env, merchant: Address, token: Address) -> bool {
+        merchant_component::is_token_accepted_for_merchant(&env, &merchant, &token)
+    }
 }

--- a/contracts/shade/src/tests/mod.rs
+++ b/contracts/shade/src/tests/mod.rs
@@ -7,6 +7,7 @@ pub mod test_admin_transfer;
 pub mod test_draft_invoice;
 pub mod test_fees;
 pub mod test_invoice;
+pub mod test_invoice_filter;
 pub mod test_invoice_partial_refund;
 pub mod test_invoice_signed;
 pub mod test_invoice_void;

--- a/contracts/shade/src/tests/test_invoice_filter.rs
+++ b/contracts/shade/src/tests/test_invoice_filter.rs
@@ -1,0 +1,251 @@
+#![cfg(test)]
+
+use crate::shade::{Shade, ShadeClient};
+use crate::types::{InvoiceFilter, InvoiceStatus};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{Address, Env, String};
+
+fn setup_test() -> (Env, ShadeClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Shade, ());
+    let client = ShadeClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, contract_id, admin)
+}
+
+fn create_token(env: &Env) -> Address {
+    env.register_stellar_asset_contract_v2(Address::generate(env))
+        .address()
+}
+
+/// Creates three invoices at timestamps 1000, 2000, and 3000.
+/// Returns (client, merchant, token, [id1, id2, id3]).
+fn setup_invoices_at_timestamps(
+    env: &Env,
+    client: &ShadeClient<'_>,
+    admin: &Address,
+) -> (Address, Address, [u64; 3]) {
+    let merchant = Address::generate(env);
+    client.register_merchant(&merchant);
+
+    let token = create_token(env);
+    client.add_accepted_token(admin, &token);
+
+    env.ledger().set_timestamp(1_000);
+    let id1 = client.create_invoice(
+        &merchant,
+        &String::from_str(env, "Invoice 1"),
+        &100,
+        &token,
+        &None,
+    );
+
+    env.ledger().set_timestamp(2_000);
+    let id2 = client.create_invoice(
+        &merchant,
+        &String::from_str(env, "Invoice 2"),
+        &200,
+        &token,
+        &None,
+    );
+
+    env.ledger().set_timestamp(3_000);
+    let id3 = client.create_invoice(
+        &merchant,
+        &String::from_str(env, "Invoice 3"),
+        &300,
+        &token,
+        &None,
+    );
+
+    (merchant, token, [id1, id2, id3])
+}
+
+#[test]
+fn test_filter_no_dates_returns_all() {
+    let (env, client, _contract_id, admin) = setup_test();
+    let (_merchant, _token, ids) = setup_invoices_at_timestamps(&env, &client, &admin);
+
+    let filter = InvoiceFilter {
+        status: None,
+        merchant: None,
+        min_amount: None,
+        max_amount: None,
+        start_date: None,
+        end_date: None,
+    };
+
+    let result = client.get_invoices(&filter);
+    assert_eq!(result.len(), 3);
+    assert_eq!(result.get(0).unwrap().id, ids[0]);
+    assert_eq!(result.get(1).unwrap().id, ids[1]);
+    assert_eq!(result.get(2).unwrap().id, ids[2]);
+}
+
+#[test]
+fn test_filter_by_start_date() {
+    let (env, client, _contract_id, admin) = setup_test();
+    setup_invoices_at_timestamps(&env, &client, &admin);
+
+    // Only invoices created at or after timestamp 2000 should be returned
+    let filter = InvoiceFilter {
+        status: None,
+        merchant: None,
+        min_amount: None,
+        max_amount: None,
+        start_date: Some(2_000),
+        end_date: None,
+    };
+
+    let result = client.get_invoices(&filter);
+    assert_eq!(result.len(), 2);
+    assert_eq!(result.get(0).unwrap().date_created, 2_000);
+    assert_eq!(result.get(1).unwrap().date_created, 3_000);
+}
+
+#[test]
+fn test_filter_by_end_date() {
+    let (env, client, _contract_id, admin) = setup_test();
+    setup_invoices_at_timestamps(&env, &client, &admin);
+
+    // Only invoices created at or before timestamp 2000 should be returned
+    let filter = InvoiceFilter {
+        status: None,
+        merchant: None,
+        min_amount: None,
+        max_amount: None,
+        start_date: None,
+        end_date: Some(2_000),
+    };
+
+    let result = client.get_invoices(&filter);
+    assert_eq!(result.len(), 2);
+    assert_eq!(result.get(0).unwrap().date_created, 1_000);
+    assert_eq!(result.get(1).unwrap().date_created, 2_000);
+}
+
+#[test]
+fn test_filter_by_date_range() {
+    let (env, client, _contract_id, admin) = setup_test();
+    setup_invoices_at_timestamps(&env, &client, &admin);
+
+    // Only the invoice at timestamp 2000 falls within [2000, 2000]
+    let filter = InvoiceFilter {
+        status: None,
+        merchant: None,
+        min_amount: None,
+        max_amount: None,
+        start_date: Some(2_000),
+        end_date: Some(2_000),
+    };
+
+    let result = client.get_invoices(&filter);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result.get(0).unwrap().date_created, 2_000);
+}
+
+#[test]
+fn test_filter_exact_boundary_dates() {
+    let (env, client, _contract_id, admin) = setup_test();
+    setup_invoices_at_timestamps(&env, &client, &admin);
+
+    // start_date == timestamp of first invoice: all three should match
+    let filter = InvoiceFilter {
+        status: None,
+        merchant: None,
+        min_amount: None,
+        max_amount: None,
+        start_date: Some(1_000),
+        end_date: Some(3_000),
+    };
+
+    let result = client.get_invoices(&filter);
+    assert_eq!(result.len(), 3);
+
+    // start_date one past the last invoice: none should match
+    let filter_empty = InvoiceFilter {
+        status: None,
+        merchant: None,
+        min_amount: None,
+        max_amount: None,
+        start_date: Some(3_001),
+        end_date: None,
+    };
+
+    let result_empty = client.get_invoices(&filter_empty);
+    assert_eq!(result_empty.len(), 0);
+}
+
+#[test]
+fn test_filter_date_range_no_matches() {
+    let (env, client, _contract_id, admin) = setup_test();
+    setup_invoices_at_timestamps(&env, &client, &admin);
+
+    // Range that doesn't overlap with any invoice timestamps
+    let filter = InvoiceFilter {
+        status: None,
+        merchant: None,
+        min_amount: None,
+        max_amount: None,
+        start_date: Some(4_000),
+        end_date: Some(5_000),
+    };
+
+    let result = client.get_invoices(&filter);
+    assert_eq!(result.len(), 0);
+}
+
+#[test]
+fn test_filter_date_combined_with_status() {
+    let (env, client, _contract_id, admin) = setup_test();
+    let (_merchant, _token, _ids) = setup_invoices_at_timestamps(&env, &client, &admin);
+
+    // All invoices are Pending (status 0); filter by date range + Pending status
+    let filter = InvoiceFilter {
+        status: Some(InvoiceStatus::Pending as u32),
+        merchant: None,
+        min_amount: None,
+        max_amount: None,
+        start_date: Some(1_000),
+        end_date: Some(2_000),
+    };
+
+    let result = client.get_invoices(&filter);
+    assert_eq!(result.len(), 2);
+
+    // Filter by date range + a non-existent status should return nothing
+    let filter_paid = InvoiceFilter {
+        status: Some(InvoiceStatus::Paid as u32),
+        merchant: None,
+        min_amount: None,
+        max_amount: None,
+        start_date: Some(1_000),
+        end_date: Some(3_000),
+    };
+
+    let result_paid = client.get_invoices(&filter_paid);
+    assert_eq!(result_paid.len(), 0);
+}
+
+#[test]
+fn test_filter_date_combined_with_amount_range() {
+    let (env, client, _contract_id, admin) = setup_test();
+    setup_invoices_at_timestamps(&env, &client, &admin);
+
+    // Invoices in date range [1000, 2000] with amount >= 200 → only invoice 2 (amount=200)
+    let filter = InvoiceFilter {
+        status: None,
+        merchant: None,
+        min_amount: Some(200),
+        max_amount: None,
+        start_date: Some(1_000),
+        end_date: Some(2_000),
+    };
+
+    let result = client.get_invoices(&filter);
+    assert_eq!(result.len(), 1);
+    assert_eq!(result.get(0).unwrap().amount, 200);
+    assert_eq!(result.get(0).unwrap().date_created, 2_000);
+}

--- a/contracts/shade/src/tests/test_merchant_tokens.rs
+++ b/contracts/shade/src/tests/test_merchant_tokens.rs
@@ -201,3 +201,226 @@ fn test_non_merchant_cannot_set_tokens() {
         soroban_sdk::Error::from_contract_error(ContractError::MerchantNotFound as u32);
     assert!(matches!(result, Err(Ok(err)) if err == expected_error));
 }
+
+#[test]
+fn test_duplicate_tokens_are_deduplicated() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(Shade, ());
+    let client = ShadeClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant = Address::generate(&env);
+    client.register_merchant(&merchant);
+
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+    client.add_accepted_token(&admin, &token);
+
+    // Pass the same token twice
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(token.clone());
+    tokens.push_back(token.clone());
+    client.set_merchant_accepted_tokens(&merchant, &tokens);
+
+    let merchant_tokens = client.get_merchant_accepted_tokens(&merchant);
+    assert_eq!(merchant_tokens.len(), 1);
+    assert_eq!(merchant_tokens.get(0).unwrap(), token);
+}
+
+#[test]
+fn test_merchant_can_overwrite_whitelist() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(Shade, ());
+    let client = ShadeClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant = Address::generate(&env);
+    client.register_merchant(&merchant);
+
+    let token_admin = Address::generate(&env);
+    let token1 = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token2 = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+
+    client.add_accepted_token(&admin, &token1);
+    client.add_accepted_token(&admin, &token2);
+
+    // Set to token1 only
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(token1.clone());
+    client.set_merchant_accepted_tokens(&merchant, &tokens);
+
+    let merchant_tokens = client.get_merchant_accepted_tokens(&merchant);
+    assert_eq!(merchant_tokens.len(), 1);
+
+    // Overwrite with token2 only
+    let mut tokens2 = Vec::new(&env);
+    tokens2.push_back(token2.clone());
+    client.set_merchant_accepted_tokens(&merchant, &tokens2);
+
+    let merchant_tokens = client.get_merchant_accepted_tokens(&merchant);
+    assert_eq!(merchant_tokens.len(), 1);
+    assert_eq!(merchant_tokens.get(0).unwrap(), token2);
+
+    // token1 should no longer be accepted by this merchant
+    assert!(!client.is_token_accepted_for_merchant(&merchant, &token1));
+    assert!(client.is_token_accepted_for_merchant(&merchant, &token2));
+}
+
+#[test]
+fn test_remove_merchant_accepted_token() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(Shade, ());
+    let client = ShadeClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant = Address::generate(&env);
+    client.register_merchant(&merchant);
+
+    let token_admin = Address::generate(&env);
+    let token1 = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token2 = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+
+    client.add_accepted_token(&admin, &token1);
+    client.add_accepted_token(&admin, &token2);
+
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(token1.clone());
+    tokens.push_back(token2.clone());
+    client.set_merchant_accepted_tokens(&merchant, &tokens);
+
+    assert_eq!(client.get_merchant_accepted_tokens(&merchant).len(), 2);
+
+    // Remove token1
+    client.remove_merchant_accepted_token(&merchant, &token1);
+
+    let merchant_tokens = client.get_merchant_accepted_tokens(&merchant);
+    assert_eq!(merchant_tokens.len(), 1);
+    assert_eq!(merchant_tokens.get(0).unwrap(), token2);
+}
+
+#[test]
+fn test_remove_nonexistent_token_fails() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(Shade, ());
+    let client = ShadeClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant = Address::generate(&env);
+    client.register_merchant(&merchant);
+
+    let token_admin = Address::generate(&env);
+    let token1 = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token2 = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+
+    client.add_accepted_token(&admin, &token1);
+    client.add_accepted_token(&admin, &token2);
+
+    // Only set token1
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(token1.clone());
+    client.set_merchant_accepted_tokens(&merchant, &tokens);
+
+    // Try to remove token2 which is not in the merchant's list
+    let result = client.try_remove_merchant_accepted_token(&merchant, &token2);
+    let expected_error =
+        soroban_sdk::Error::from_contract_error(ContractError::TokenNotAccepted as u32);
+    assert!(matches!(result, Err(Ok(err)) if err == expected_error));
+}
+
+#[test]
+fn test_inactive_merchant_cannot_set_tokens() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(Shade, ());
+    let client = ShadeClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant = Address::generate(&env);
+    client.register_merchant(&merchant);
+
+    // Deactivate the merchant
+    client.set_merchant_status(&admin, &1, &false);
+
+    let token = env
+        .register_stellar_asset_contract_v2(Address::generate(&env))
+        .address();
+    client.add_accepted_token(&admin, &token);
+
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(token);
+
+    let result = client.try_set_merchant_accepted_tokens(&merchant, &tokens);
+    let expected_error =
+        soroban_sdk::Error::from_contract_error(ContractError::MerchantNotActive as u32);
+    assert!(matches!(result, Err(Ok(err)) if err == expected_error));
+}
+
+#[test]
+fn test_is_token_accepted_for_merchant_public() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register(Shade, ());
+    let client = ShadeClient::new(&env, &contract_id);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let merchant = Address::generate(&env);
+    client.register_merchant(&merchant);
+
+    let token_admin = Address::generate(&env);
+    let token1 = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    let token2 = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+
+    client.add_accepted_token(&admin, &token1);
+    client.add_accepted_token(&admin, &token2);
+
+    // No merchant whitelist set — both global tokens should be accepted
+    assert!(client.is_token_accepted_for_merchant(&merchant, &token1));
+    assert!(client.is_token_accepted_for_merchant(&merchant, &token2));
+
+    // Set merchant whitelist to only token1
+    let mut tokens = Vec::new(&env);
+    tokens.push_back(token1.clone());
+    client.set_merchant_accepted_tokens(&merchant, &tokens);
+
+    assert!(client.is_token_accepted_for_merchant(&merchant, &token1));
+    assert!(!client.is_token_accepted_for_merchant(&merchant, &token2));
+}


### PR DESCRIPTION
## feat: Merchant Token Whitelist — per-merchant payment token control

Closes #140

### Summary

- Merchants can now specify a **subset of the global token whitelist** they wish to accept for invoices
- Adds **duplicate token prevention** when setting merchant tokens
- Adds **active merchant guard** — inactive merchants cannot modify their whitelist
- Adds **granular token removal** (`remove_merchant_accepted_token`) so merchants don't have to reset the entire list to drop one token
- Exposes `is_token_accepted_for_merchant` as a **public contract method** for external callers to query acceptance before submitting

### What changed

| File | Change |
|------|--------|
| `contracts/shade/src/components/merchant.rs` | Enhanced `set_merchant_accepted_tokens` with dedup + active check; added `remove_merchant_accepted_token` |
| `contracts/shade/src/interface.rs` | Exposed `remove_merchant_accepted_token` and `is_token_accepted_for_merchant` in the public trait |
| `contracts/shade/src/shade.rs` | Wired new public methods; `remove_merchant_accepted_token` is pause-guarded |
| `contracts/shade/src/events.rs` | Added `MerchantTokenRemovedEvent` |
| `contracts/shade/src/tests/test_merchant_tokens.rs` | 6 new tests (11 total) |

### How it works

1. **Storage:** `DataKey::MerchantTokens(Address)` stores a `Vec<Address>` per merchant
2. **Validation on set:** Every token in the merchant's list must already exist in the global whitelist; duplicates are silently deduplicated
3. **Validation on invoice creation:** `validate_invoice_creation` checks the global whitelist first, then the merchant whitelist. If a merchant has not set any tokens, all globally accepted tokens are allowed (backward compatible)
4. **Removal:** `remove_merchant_accepted_token` removes a single token from the merchant's list and emits `MerchantTokenRemovedEvent`. Panics with `TokenNotAccepted` if the token is not in the merchant's list

### New tests

| Test | Verifies |
|------|----------|
| `test_duplicate_tokens_are_deduplicated` | Passing the same token twice results in a single entry |
| `test_merchant_can_overwrite_whitelist` | Setting a new list fully replaces the old one; `is_token_accepted_for_merchant` reflects the change |
| `test_remove_merchant_accepted_token` | Single-token removal works and list shrinks correctly |
| `test_remove_nonexistent_token_fails` | Removing a token not in the merchant's list panics with `TokenNotAccepted` |
| `test_inactive_merchant_cannot_set_tokens` | Deactivated merchants are blocked from modifying their whitelist |
| `test_is_token_accepted_for_merchant_public` | Public query returns correct results before and after setting a merchant whitelist |

### Test plan

- [x] All 11 merchant token tests pass
- [x] Full suite (183 tests) passes with zero failures
- [x] `cargo build` compiles cleanly
