### PR TITLE
feat(merchant): support webhook registration parameters (#189)

### DIFF
--- a/contracts/shade/src/components/merchant.rs
+++ b/contracts/shade/src/components/merchant.rs
@@ -4,7 +4,7 @@ use crate::components::core as core_component;
 use crate::errors::ContractError;
 use crate::events;
 use crate::types::{DataKey, Merchant, MerchantFilter, Role};
-use soroban_sdk::{contractclient, panic_with_error, Address, BytesN, Env, Vec};
+use soroban_sdk::{contractclient, panic_with_error, Address, BytesN, Env, String, Vec};
 
 #[contractclient(name = "MerchantAccountClient")]
 pub trait MerchantAccountContract {
@@ -37,6 +37,7 @@ pub fn register_merchant(env: &Env, merchant: &Address) {
         verified: false,
         date_registered: env.ledger().timestamp(),
         account: merchant.clone(),
+        webhook: String::from_str(env, ""),
     };
 
     env.storage()
@@ -394,6 +395,40 @@ pub fn get_merchant_accepted_tokens(env: &Env, merchant: &Address) -> Vec<Addres
         .persistent()
         .get(&DataKey::MerchantTokens(merchant.clone()))
         .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn set_merchant_webhook(env: &Env, merchant: &Address, webhook: &String) {
+    merchant.require_auth();
+
+    if !is_merchant(env, merchant) {
+        panic_with_error!(env, ContractError::MerchantNotFound);
+    }
+
+    let merchant_id = get_merchant_id(env, merchant);
+    let mut merchant_data: Merchant = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Merchant(merchant_id))
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::MerchantNotFound));
+
+    merchant_data.webhook = webhook.clone();
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Merchant(merchant_id), &merchant_data);
+
+    events::publish_merchant_webhook_set_event(
+        env,
+        merchant.clone(),
+        merchant_id,
+        webhook.clone(),
+        env.ledger().timestamp(),
+    );
+}
+
+pub fn get_merchant_webhook(env: &Env, merchant_id: u64) -> String {
+    let merchant_data = get_merchant(env, merchant_id);
+    merchant_data.webhook
 }
 
 pub fn is_token_accepted_for_merchant(env: &Env, merchant: &Address, token: &Address) -> bool {

--- a/contracts/shade/src/events.rs
+++ b/contracts/shade/src/events.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contractevent, Address, BytesN, Env, Vec};
+use soroban_sdk::{contractevent, Address, BytesN, Env, String, Vec};
 
 // ── Existing events ───────────────────────────────────────────────────────────
 
@@ -182,6 +182,30 @@ pub fn publish_merchant_verified_event(env: &Env, merchant_id: u64, status: bool
     MerchantVerifiedEvent {
         merchant_id,
         status,
+        timestamp,
+    }
+    .publish(env);
+}
+
+#[contractevent]
+pub struct MerchantWebhookSetEvent {
+    pub merchant: Address,
+    pub merchant_id: u64,
+    pub webhook: String,
+    pub timestamp: u64,
+}
+
+pub fn publish_merchant_webhook_set_event(
+    env: &Env,
+    merchant: Address,
+    merchant_id: u64,
+    webhook: String,
+    timestamp: u64,
+) {
+    MerchantWebhookSetEvent {
+        merchant,
+        merchant_id,
+        webhook,
         timestamp,
     }
     .publish(env);

--- a/contracts/shade/src/interface.rs
+++ b/contracts/shade/src/interface.rs
@@ -89,6 +89,9 @@ pub trait ShadeTrait {
         new_description: Option<String>,
     );
 
+    fn set_merchant_webhook(env: Env, merchant: Address, webhook: String);
+    fn get_merchant_webhook(env: Env, merchant_id: u64) -> String;
+
     fn set_merchant_accepted_tokens(env: Env, merchant: Address, tokens: Vec<Address>);
     fn get_merchant_accepted_tokens(env: Env, merchant: Address) -> Vec<Address>;
     fn remove_merchant_accepted_token(env: Env, merchant: Address, token: Address);

--- a/contracts/shade/src/shade.rs
+++ b/contracts/shade/src/shade.rs
@@ -337,6 +337,15 @@ impl ShadeTrait for Shade {
         subscription_component::cancel_subscription(&env, caller, subscription_id);
     }
 
+    fn set_merchant_webhook(env: Env, merchant: Address, webhook: String) {
+        pausable_component::assert_not_paused(&env);
+        merchant_component::set_merchant_webhook(&env, &merchant, &webhook);
+    }
+
+    fn get_merchant_webhook(env: Env, merchant_id: u64) -> String {
+        merchant_component::get_merchant_webhook(&env, merchant_id)
+    }
+
     fn set_merchant_accepted_tokens(env: Env, merchant: Address, tokens: Vec<Address>) {
         pausable_component::assert_not_paused(&env);
         merchant_component::set_merchant_accepted_tokens(&env, &merchant, &tokens);

--- a/contracts/shade/src/tests/mod.rs
+++ b/contracts/shade/src/tests/mod.rs
@@ -1,4 +1,4 @@
-﻿pub mod test;
+pub mod test;
 pub mod test_accepted_tokens;
 pub mod test_access_control;
 pub mod test_account_factory;
@@ -23,6 +23,7 @@ pub mod test_merchant_activation;
 pub mod test_merchant_key;
 pub mod test_merchant_tokens;
 mod test_merchant_verification;
+pub mod test_merchant_webhook;
 pub mod test_pausable;
 pub mod test_payment;
 pub mod test_querying;

--- a/contracts/shade/src/tests/test_merchant_webhook.rs
+++ b/contracts/shade/src/tests/test_merchant_webhook.rs
@@ -1,0 +1,137 @@
+#![cfg(test)]
+
+use crate::shade::{Shade, ShadeClient};
+use soroban_sdk::testutils::{Address as _, Events as _};
+use soroban_sdk::{Address, Env, Map, String, Symbol, TryIntoVal, Val};
+
+fn setup_test() -> (Env, ShadeClient<'static>, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(Shade, ());
+    let client = ShadeClient::new(&env, &contract_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    (env, client, contract_id, admin)
+}
+
+#[test]
+fn test_merchant_webhook_defaults_to_empty() {
+    let (env, client, _contract_id, _admin) = setup_test();
+
+    let merchant = Address::generate(&env);
+    client.register_merchant(&merchant);
+
+    let webhook = client.get_merchant_webhook(&1u64);
+    assert_eq!(webhook, String::from_str(&env, ""));
+}
+
+#[test]
+fn test_set_merchant_webhook_success() {
+    let (env, client, contract_id, _admin) = setup_test();
+
+    let merchant = Address::generate(&env);
+    client.register_merchant(&merchant);
+
+    let webhook = String::from_str(&env, "https://relay.example.com/hook");
+    client.set_merchant_webhook(&merchant, &webhook);
+    let events = env.events().all();
+
+    assert!(!events.is_empty(), "No events captured after webhook set");
+
+    let (event_contract_id, _topics, data) = events.get(events.len() - 1).unwrap();
+    assert_eq!(event_contract_id, contract_id.clone());
+
+    let data_map: Map<Symbol, Val> = data.try_into_val(&env).expect("Data should be a Map");
+
+    let merchant_val = data_map
+        .get(Symbol::new(&env, "merchant"))
+        .expect("Should have merchant field");
+    let merchant_id_val = data_map
+        .get(Symbol::new(&env, "merchant_id"))
+        .expect("Should have merchant_id field");
+    let webhook_val = data_map
+        .get(Symbol::new(&env, "webhook"))
+        .expect("Should have webhook field");
+
+    let merchant_in_event: Address = merchant_val.try_into_val(&env).unwrap();
+    let merchant_id_in_event: u64 = merchant_id_val.try_into_val(&env).unwrap();
+    let webhook_in_event: String = webhook_val.try_into_val(&env).unwrap();
+
+    assert_eq!(merchant_in_event, merchant.clone());
+    assert_eq!(merchant_id_in_event, 1u64);
+    assert_eq!(webhook_in_event, webhook.clone());
+
+    assert_eq!(client.get_merchant_webhook(&1u64), webhook);
+
+    let merchant_data = client.get_merchant(&1u64);
+    assert_eq!(merchant_data.webhook, webhook);
+}
+
+#[test]
+fn test_update_merchant_webhook() {
+    let (env, client, _contract_id, _admin) = setup_test();
+
+    let merchant = Address::generate(&env);
+    client.register_merchant(&merchant);
+
+    let webhook1 = String::from_str(&env, "https://relay.example.com/hook");
+    client.set_merchant_webhook(&merchant, &webhook1);
+    assert_eq!(client.get_merchant_webhook(&1u64), webhook1);
+
+    let webhook2 = String::from_str(&env, "https://new.example.com/v2/hook");
+    client.set_merchant_webhook(&merchant, &webhook2);
+    assert_eq!(client.get_merchant_webhook(&1u64), webhook2);
+}
+
+#[test]
+fn test_clear_merchant_webhook() {
+    let (env, client, _contract_id, _admin) = setup_test();
+
+    let merchant = Address::generate(&env);
+    client.register_merchant(&merchant);
+
+    let webhook = String::from_str(&env, "https://relay.example.com/hook");
+    client.set_merchant_webhook(&merchant, &webhook);
+    assert_eq!(client.get_merchant_webhook(&1u64), webhook);
+
+    let empty = String::from_str(&env, "");
+    client.set_merchant_webhook(&merchant, &empty);
+    assert_eq!(client.get_merchant_webhook(&1u64), empty);
+}
+
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #6)")]
+fn test_set_webhook_for_unregistered_merchant_fails() {
+    let (env, client, _contract_id, _admin) = setup_test();
+
+    let unregistered = Address::generate(&env);
+    let webhook = String::from_str(&env, "https://relay.example.com/hook");
+    client.set_merchant_webhook(&unregistered, &webhook);
+}
+
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #6)")]
+fn test_get_webhook_for_nonexistent_merchant_fails() {
+    let (_env, client, _contract_id, _admin) = setup_test();
+
+    client.get_merchant_webhook(&99u64);
+}
+
+#[test]
+fn test_webhooks_are_per_merchant() {
+    let (env, client, _contract_id, _admin) = setup_test();
+
+    let merchant_1 = Address::generate(&env);
+    let merchant_2 = Address::generate(&env);
+    client.register_merchant(&merchant_1);
+    client.register_merchant(&merchant_2);
+
+    let webhook_1 = String::from_str(&env, "https://m1.example.com/hook");
+    let webhook_2 = String::from_str(&env, "https://m2.example.com/hook");
+
+    client.set_merchant_webhook(&merchant_1, &webhook_1);
+    client.set_merchant_webhook(&merchant_2, &webhook_2);
+
+    assert_eq!(client.get_merchant_webhook(&1u64), webhook_1);
+    assert_eq!(client.get_merchant_webhook(&2u64), webhook_2);
+}

--- a/contracts/shade/src/types.rs
+++ b/contracts/shade/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, BytesN};
+use soroban_sdk::{contracttype, Address, BytesN, String};
 
 #[contracttype]
 pub enum DataKey {
@@ -50,6 +50,7 @@ pub struct Merchant {
     pub verified: bool,
     pub date_registered: u64,
     pub account: Address,
+    pub webhook: String,
 }
 
 #[contracttype]


### PR DESCRIPTION
## Description

Adds on-chain webhook registration for merchants so off-chain relays can react to payment events without polling. Implements issue #189.

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Related Issues

Fixes #189

## Changes Made

- Added `webhook: String` field to `Merchant` struct, initialized to empty on registration.
- Added `set_merchant_webhook(merchant, webhook)` and `get_merchant_webhook(merchant_id) -> String` endpoints. Only the merchant can update their own webhook (`require_auth`).
- Added `MerchantWebhookSetEvent { merchant, merchant_id, webhook, timestamp }` so relays can update their registry in real time.
- Exposed the new endpoints through `ShadeTrait` and `impl Shade`.
- `InvoicePaidEvent` and `SubscriptionChargedEvent` are already structured for webhook parsing — both carry `merchant_id` / `merchant`, fee split, token, and timestamp — so no schema change was needed to satisfy the acceptance criteria.

## Testing

- [x] I have added tests that prove my fix is effective or that my feature works
- [x] All existing tests pass locally
- [x] I have tested this manually

New test file `contracts/shade/src/tests/test_merchant_webhook.rs` covers:

- Webhook defaults to empty after registration.
- Successful set emits `MerchantWebhookSetEvent` with expected fields.
- Webhooks can be updated and cleared.
- Setting a webhook on an unregistered merchant panics with `MerchantNotFound`.
- Reading the webhook for a non-existent merchant id panics with `MerchantNotFound`.
- Webhooks are isolated per merchant.

Commands run locally:

- `cargo test --workspace --all-features` — 302 passed, 0 failed.
- `cargo fmt --all -- --check` — clean.
- `cargo clippy --workspace --all-features -- -D warnings` — clean.

## Checklist

- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation (no docs affected)
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Additional Notes

The design keeps events lean and pushes the URL lookup to the relay via `get_merchant_webhook(merchant_id)`. This avoids bloating every payment event with a potentially long URL and lets merchants rotate webhooks without invalidating historical events.