### PR TITLE
Implement oracle-priced fiat invoices, analytics aggregation, platform splits, and bridge placeholders

### DIFF
--- a/PR_NOTES_198_184_202_190.md
+++ b/PR_NOTES_198_184_202_190.md
@@ -1,0 +1,59 @@
+# PR: Integrate oracle pricing, analytics aggregation, cross-chain placeholders, and platform splits
+
+## Covered issues
+- #198 Integrate Price Oracle for Fiat-to-Crypto Dynamic Pricing
+- #184 Implement Comprehensive Analytics Aggregation Logic
+- #202 Implement Cross-chain Payment Proxy Placeholders
+- #190 Implement Payment Routing for Platform Splits
+
+## Summary
+This PR extends the `shade` contract to support fixed-fiat invoices that resolve into token amounts through an admin-configured oracle, formalizes merchant analytics storage, routes platform fees to a dedicated platform account, and adds placeholder cross-chain payload/event support for future bridge integrations.
+
+## What changed
+
+### #198 Oracle-backed fiat pricing
+- Added `OracleConfig` storage keyed by settlement token.
+- Added `create_fiat_invoice(...)` to create invoices priced in fiat while still settling in crypto.
+- Added `resolve_invoice_amount(...)` so callers can fetch the current crypto amount for an unpaid invoice.
+- Added invoice pricing metadata via `InvoicePricingMode` and `FiatPricing`.
+- Before the first payment on a fiat invoice, the contract refreshes the crypto amount from the configured oracle and persists that quote for settlement/refunds.
+
+### #184 Analytics aggregation
+- Added `MerchantAnalytics` per merchant/token and `MerchantAnalyticsSummary` per merchant.
+- Updated invoice payments and subscription charges to record:
+  - total settled volume
+  - total platform fees
+  - transaction count
+  - last updated timestamp
+- Preserved the existing `get_merchant_volume(...)` surface by backing it with the new analytics state.
+- Added `get_merchant_analytics(...)` and `get_merchant_analytics_summary(...)`.
+
+### #190 Platform split routing
+- Added `PlatformAccount` storage with admin setter/getter.
+- Initialized platform routing to the admin address by default.
+- Routed platform fee amounts directly to the configured platform account instead of holding them on the contract.
+- Emitted a dedicated `PaymentSplitRoutedEvent` for split visibility.
+- Reused the existing token fee basis points as the split percentage.
+
+### #202 Cross-chain placeholders
+- Added `CrossChainBridgePayload` as the placeholder payload type for future bridge integrations.
+- Added `emit_cross_chain_bridge_placeholder(...)` to publish a bridge placeholder event without changing settlement logic.
+- Added `CrossChainBridgePlaceholderEvent`.
+
+## Notes
+- No tests or build verification were run for this branch by request.
+- Fiat invoice settlement assumes the configured oracle exposes `get_price(token, quote_currency) -> i128`.
+- Fiat amounts are expected to be passed in minor units, with `fiat_decimals` describing the scale.
+
+## Ready PR title
+Implement oracle-priced fiat invoices, analytics aggregation, platform splits, and bridge placeholders
+
+## Ready review comment
+Implemented all four requested issues in one branch.
+
+- `#198`: Added oracle configuration per token, introduced fixed-fiat invoice creation, and refresh the oracle quote immediately before first settlement so unpaid fiat invoices convert into crypto using the latest available rate.
+- `#184`: Added structured merchant analytics storage and updated both invoice payments and subscription charges to increment on-chain volume, fee totals, and transaction counts. Existing merchant-volume reads still work, and there are now richer analytics getters as well.
+- `#190`: The existing token fee basis points now act as the split percentage, and fee proceeds are routed directly to a configurable platform account while the merchant share continues to go to the merchant account. A split-routing event was added for auditability.
+- `#202`: Added a cross-chain bridge payload struct and a placeholder event emitter so future bridge/proxy integrations can build on a stable contract surface without changing current payment behavior.
+
+No test run or build verification was performed on this branch, per instruction.

--- a/contracts/shade/src/components/admin.rs
+++ b/contracts/shade/src/components/admin.rs
@@ -1,7 +1,9 @@
 use crate::components::{core, reentrancy};
 use crate::errors::ContractError;
 use crate::events;
-use crate::types::{DataKey, PendingFee};
+use crate::types::{
+    DataKey, MerchantAnalytics, MerchantAnalyticsSummary, OracleConfig, PendingFee,
+};
 use soroban_sdk::{panic_with_error, token, Address, Env, Vec};
 
 pub const FEE_UPDATE_DELAY: u64 = 172_800; // 48 hours in seconds
@@ -131,6 +133,57 @@ pub fn get_fee(env: &Env, token: &Address) -> i128 {
         .unwrap_or(0)
 }
 
+pub fn set_platform_account(env: &Env, admin: &Address, account: &Address) {
+    reentrancy::enter(env);
+    core::assert_admin(env, admin);
+    env.storage()
+        .persistent()
+        .set(&DataKey::PlatformAccount, account);
+    events::publish_platform_account_set_event(
+        env,
+        admin.clone(),
+        account.clone(),
+        env.ledger().timestamp(),
+    );
+    reentrancy::exit(env);
+}
+
+pub fn get_platform_account(env: &Env) -> Address {
+    env.storage()
+        .persistent()
+        .get(&DataKey::PlatformAccount)
+        .unwrap_or_else(|| core::get_admin(env))
+}
+
+pub fn set_token_oracle(env: &Env, admin: &Address, token: &Address, oracle: &OracleConfig) {
+    reentrancy::enter(env);
+    core::assert_admin(env, admin);
+
+    if !is_accepted_token(env, token) {
+        panic_with_error!(env, ContractError::TokenNotAccepted);
+    }
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::TokenOracle(token.clone()), oracle);
+
+    events::publish_token_oracle_set_event(
+        env,
+        admin.clone(),
+        token.clone(),
+        oracle.contract.clone(),
+        env.ledger().timestamp(),
+    );
+    reentrancy::exit(env);
+}
+
+pub fn get_token_oracle(env: &Env, token: &Address) -> OracleConfig {
+    env.storage()
+        .persistent()
+        .get(&DataKey::TokenOracle(token.clone()))
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::OracleNotConfigured))
+}
+
 pub fn calculate_fee(env: &Env, merchant: &Address, token: &Address, amount: i128) -> i128 {
     let fee_bps: i128 = get_fee(env, token);
     if fee_bps == 0 {
@@ -144,17 +197,71 @@ pub fn calculate_fee(env: &Env, merchant: &Address, token: &Address, amount: i12
 }
 
 pub fn get_merchant_volume(env: &Env, merchant: &Address, token: &Address) -> i128 {
-    env.storage()
-        .persistent()
-        .get(&DataKey::MerchantVolume(merchant.clone(), token.clone()))
-        .unwrap_or(0)
+    get_merchant_analytics(env, merchant, token).total_volume
 }
 
-pub fn increment_merchant_volume(env: &Env, merchant: &Address, token: &Address, amount: i128) {
-    let current = get_merchant_volume(env, merchant, token);
+pub fn get_merchant_analytics(env: &Env, merchant: &Address, token: &Address) -> MerchantAnalytics {
+    env.storage()
+        .persistent()
+        .get(&DataKey::MerchantAnalytics(merchant.clone(), token.clone()))
+        .unwrap_or(MerchantAnalytics {
+            merchant: merchant.clone(),
+            token: token.clone(),
+            total_volume: env
+                .storage()
+                .persistent()
+                .get(&DataKey::MerchantVolume(merchant.clone(), token.clone()))
+                .unwrap_or(0),
+            total_fees: 0,
+            transaction_count: 0,
+            last_updated: 0,
+        })
+}
+
+pub fn get_merchant_analytics_summary(env: &Env, merchant: &Address) -> MerchantAnalyticsSummary {
+    env.storage()
+        .persistent()
+        .get(&DataKey::MerchantAnalyticsSummary(merchant.clone()))
+        .unwrap_or(MerchantAnalyticsSummary {
+            merchant: merchant.clone(),
+            total_volume: 0,
+            total_fees: 0,
+            transaction_count: 0,
+            last_updated: 0,
+        })
+}
+
+pub fn record_merchant_payment(
+    env: &Env,
+    merchant: &Address,
+    token: &Address,
+    volume_amount: i128,
+    fee_amount: i128,
+) {
+    let mut analytics = get_merchant_analytics(env, merchant, token);
+    analytics.total_volume += volume_amount;
+    analytics.total_fees += fee_amount;
+    analytics.transaction_count += 1;
+    analytics.last_updated = env.ledger().timestamp();
+
+    env.storage().persistent().set(
+        &DataKey::MerchantAnalytics(merchant.clone(), token.clone()),
+        &analytics,
+    );
     env.storage().persistent().set(
         &DataKey::MerchantVolume(merchant.clone(), token.clone()),
-        &(current + amount),
+        &analytics.total_volume,
+    );
+
+    let mut summary = get_merchant_analytics_summary(env, merchant);
+    summary.total_volume += volume_amount;
+    summary.total_fees += fee_amount;
+    summary.transaction_count += 1;
+    summary.last_updated = analytics.last_updated;
+
+    env.storage().persistent().set(
+        &DataKey::MerchantAnalyticsSummary(merchant.clone()),
+        &summary,
     );
 }
 

--- a/contracts/shade/src/components/invoice.rs
+++ b/contracts/shade/src/components/invoice.rs
@@ -1,7 +1,9 @@
 use crate::components::{access_control, admin, merchant, signature_util};
 use crate::errors::ContractError;
 use crate::events;
-use crate::types::{DataKey, Invoice, InvoiceFilter, InvoiceStatus, Role};
+use crate::types::{
+    DataKey, FiatPricing, Invoice, InvoiceFilter, InvoicePricingMode, InvoiceStatus, Role,
+};
 use soroban_sdk::token::TokenClient;
 use soroban_sdk::{contractclient, panic_with_error, token, Address, BytesN, Env, String, Vec};
 
@@ -10,7 +12,66 @@ pub trait MerchantAccountRefund {
     fn refund(env: Env, token: Address, amount: i128, to: Address);
 }
 
+#[contractclient(name = "PriceOracleClient")]
+pub trait PriceOracle {
+    fn get_price(env: Env, token: Address, quote_currency: String) -> i128;
+}
+
 pub const MAX_REFUND_DURATION: u64 = 604_800; // 7 days
+
+fn scale_factor(decimals: u32) -> i128 {
+    let mut factor = 1i128;
+    for _ in 0..decimals {
+        factor *= 10;
+    }
+    factor
+}
+
+fn resolve_fiat_invoice_amount(env: &Env, invoice: &Invoice) -> i128 {
+    let fiat_pricing = invoice
+        .fiat_pricing
+        .clone()
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::OraclePriceUnavailable));
+    let oracle_config = admin::get_token_oracle(env, &invoice.token);
+    let oracle_client = PriceOracleClient::new(env, &oracle_config.contract);
+    let price = oracle_client.get_price(&invoice.token, &fiat_pricing.currency);
+
+    if price <= 0 {
+        panic_with_error!(env, ContractError::OraclePriceUnavailable);
+    }
+
+    let numerator = fiat_pricing.amount
+        * scale_factor(oracle_config.token_decimals)
+        * scale_factor(oracle_config.price_decimals);
+    let denominator = price * scale_factor(fiat_pricing.decimals);
+    let resolved_amount = numerator / denominator;
+
+    if resolved_amount <= 0 {
+        panic_with_error!(env, ContractError::OraclePriceUnavailable);
+    }
+
+    resolved_amount
+}
+
+fn refresh_fiat_invoice_quote(env: &Env, invoice: &mut Invoice) {
+    if invoice.pricing_mode != InvoicePricingMode::FixedFiat || invoice.amount_paid > 0 {
+        return;
+    }
+
+    let resolved_amount = resolve_fiat_invoice_amount(env, invoice);
+    invoice.amount = resolved_amount;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Invoice(invoice.id), &*invoice);
+
+    events::publish_fiat_invoice_priced_event(
+        env,
+        invoice.id,
+        invoice.token.clone(),
+        resolved_amount,
+        env.ledger().timestamp(),
+    );
+}
 
 pub fn validate_invoice_creation(
     env: &Env,
@@ -98,6 +159,8 @@ pub fn create_invoice(
         amount_paid: 0,
         amount_refunded: 0,
         expires_at,
+        pricing_mode: InvoicePricingMode::FixedCrypto,
+        fiat_pricing: None,
     };
     env.storage()
         .persistent()
@@ -112,6 +175,87 @@ pub fn create_invoice(
         amount,
         token.clone(),
     );
+    new_invoice_id
+}
+
+pub fn create_fiat_invoice(
+    env: &Env,
+    merchant_address: &Address,
+    description: &String,
+    fiat_amount: i128,
+    fiat_currency: &String,
+    fiat_decimals: u32,
+    token: &Address,
+    expires_at: Option<u64>,
+) -> u64 {
+    merchant_address.require_auth();
+
+    if fiat_amount <= 0 {
+        panic_with_error!(env, ContractError::InvalidAmount);
+    }
+
+    let mut invoice = Invoice {
+        id: 0,
+        description: description.clone(),
+        amount: 0,
+        token: token.clone(),
+        status: InvoiceStatus::Pending,
+        merchant_id: merchant::get_merchant_id(env, merchant_address),
+        payer: None,
+        date_created: env.ledger().timestamp(),
+        date_paid: None,
+        amount_paid: 0,
+        amount_refunded: 0,
+        expires_at,
+        pricing_mode: InvoicePricingMode::FixedFiat,
+        fiat_pricing: Some(FiatPricing {
+            currency: fiat_currency.clone(),
+            amount: fiat_amount,
+            decimals: fiat_decimals,
+        }),
+    };
+
+    invoice.amount = resolve_fiat_invoice_amount(env, &invoice);
+
+    validate_invoice_creation(
+        env,
+        merchant_address,
+        description,
+        invoice.amount,
+        token,
+        expires_at,
+    );
+
+    let invoice_count: u64 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::InvoiceCount)
+        .unwrap_or(0);
+    let new_invoice_id = invoice_count + 1;
+    invoice.id = new_invoice_id;
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Invoice(new_invoice_id), &invoice);
+    env.storage()
+        .persistent()
+        .set(&DataKey::InvoiceCount, &new_invoice_id);
+
+    events::publish_invoice_created_event(
+        env,
+        new_invoice_id,
+        merchant_address.clone(),
+        invoice.amount,
+        token.clone(),
+    );
+    events::publish_fiat_invoice_priced_event(
+        env,
+        new_invoice_id,
+        token.clone(),
+        invoice.amount,
+        env.ledger().timestamp(),
+    );
+
     new_invoice_id
 }
 
@@ -154,6 +298,8 @@ pub fn create_invoice_draft(
         amount_paid: 0,
         amount_refunded: 0,
         expires_at,
+        pricing_mode: InvoicePricingMode::FixedCrypto,
+        fiat_pricing: None,
     };
     env.storage()
         .persistent()
@@ -252,6 +398,8 @@ pub fn create_invoice_signed(
         amount_paid: 0,
         amount_refunded: 0,
         expires_at: None,
+        pricing_mode: InvoicePricingMode::FixedCrypto,
+        fiat_pricing: None,
     };
 
     env.storage()
@@ -278,6 +426,15 @@ pub fn get_invoice(env: &Env, invoice_id: u64) -> Invoice {
         .persistent()
         .get(&DataKey::Invoice(invoice_id))
         .unwrap_or_else(|| panic_with_error!(env, ContractError::InvoiceNotFound))
+}
+
+pub fn resolve_invoice_amount(env: &Env, invoice_id: u64) -> i128 {
+    let invoice = get_invoice(env, invoice_id);
+    if invoice.pricing_mode == InvoicePricingMode::FixedFiat && invoice.amount_paid == 0 {
+        return resolve_fiat_invoice_amount(env, &invoice);
+    }
+
+    invoice.amount
 }
 
 pub fn check_invoice_refund_eligibility(env: &Env, merchant_address: &Address, invoice_id: u64) {
@@ -499,7 +656,7 @@ pub fn pay_invoice(env: &Env, payer: &Address, invoice_id: u64) -> i128 {
     if invoice.status != InvoiceStatus::Pending && invoice.status != InvoiceStatus::PartiallyPaid {
         panic_with_error!(env, ContractError::InvalidInvoiceStatus);
     }
-    let remaining_amount = invoice.amount - invoice.amount_paid;
+    let remaining_amount = resolve_invoice_amount(env, invoice_id) - invoice.amount_paid;
     if remaining_amount <= 0 {
         panic_with_error!(env, ContractError::InvalidInvoiceStatus);
     }
@@ -514,6 +671,7 @@ pub fn pay_invoice_partial(env: &Env, payer: &Address, invoice_id: u64, amount: 
     }
 
     let mut invoice = get_invoice(env, invoice_id);
+    refresh_fiat_invoice_quote(env, &mut invoice);
 
     if let Some(expires_at) = invoice.expires_at {
         if env.ledger().timestamp() >= expires_at {
@@ -536,15 +694,16 @@ pub fn pay_invoice_partial(env: &Env, payer: &Address, invoice_id: u64, amount: 
     let merchant_address: Address = merchant_id_to_address(env, invoice.merchant_id);
     let fee_amount = admin::calculate_fee(env, &merchant_address, &invoice.token, amount);
     let merchant_account_id = merchant::get_merchant_account(env, invoice.merchant_id);
+    let platform_account = admin::get_platform_account(env);
     let merchant_amount = amount - fee_amount;
 
     let token_client = token::TokenClient::new(env, &invoice.token);
 
     token_client.transfer(payer, &merchant_account_id, &merchant_amount);
     if fee_amount > 0 {
-        token_client.transfer(payer, env.current_contract_address(), &fee_amount);
-        admin::increment_merchant_volume(env, &merchant_address, &invoice.token, amount);
+        token_client.transfer(payer, &platform_account, &fee_amount);
     }
+    admin::record_merchant_payment(env, &merchant_address, &invoice.token, amount, fee_amount);
 
     invoice.amount_paid += amount;
     if let Some(existing_payer) = &invoice.payer {
@@ -575,6 +734,16 @@ pub fn pay_invoice_partial(env: &Env, payer: &Address, invoice_id: u64, amount: 
         amount,
         fee_amount,
         merchant_amount,
+        invoice.token.clone(),
+        env.ledger().timestamp(),
+    );
+    events::publish_payment_split_routed_event(
+        env,
+        invoice_id,
+        merchant_account_id,
+        platform_account,
+        merchant_amount,
+        fee_amount,
         invoice.token.clone(),
         env.ledger().timestamp(),
     );

--- a/contracts/shade/src/components/subscription.rs
+++ b/contracts/shade/src/components/subscription.rs
@@ -146,13 +146,14 @@ pub fn charge_subscription(env: &Env, subscription_id: u64) {
 
     let token_client = token::TokenClient::new(env, &plan.token);
     let merchant_account = merchant::get_merchant_account(env, plan.merchant_id);
+    let platform_account = admin::get_platform_account(env);
     let spender = env.current_contract_address();
 
     token_client.transfer_from(&spender, &sub.customer, &merchant_account, &merchant_amount);
     if fee > 0 {
-        token_client.transfer_from(&spender, &sub.customer, &spender, &fee);
-        admin::increment_merchant_volume(env, &plan.merchant, &plan.token, plan.amount);
+        token_client.transfer_from(&spender, &sub.customer, &platform_account, &fee);
     }
+    admin::record_merchant_payment(env, &plan.merchant, &plan.token, plan.amount, fee);
 
     sub.last_charged = now;
     env.storage()

--- a/contracts/shade/src/errors.rs
+++ b/contracts/shade/src/errors.rs
@@ -37,6 +37,8 @@ pub enum ContractError {
     InsufficientAllowance = 31,
     MerchantNotActive = 32,
     InvalidDescription = 33,
+    OracleNotConfigured = 34,
+    OraclePriceUnavailable = 35,
     TokenNotAcceptedByMerchant = 41,
     FeeUpdateTooEarly = 42,
     NoPendingFeeUpdate = 43,

--- a/contracts/shade/src/events.rs
+++ b/contracts/shade/src/events.rs
@@ -319,6 +319,51 @@ pub fn publish_fee_set_event(env: &Env, admin: Address, token: Address, fee: i12
 }
 
 #[contractevent]
+pub struct PlatformAccountSetEvent {
+    pub admin: Address,
+    pub account: Address,
+    pub timestamp: u64,
+}
+
+pub fn publish_platform_account_set_event(
+    env: &Env,
+    admin: Address,
+    account: Address,
+    timestamp: u64,
+) {
+    PlatformAccountSetEvent {
+        admin,
+        account,
+        timestamp,
+    }
+    .publish(env);
+}
+
+#[contractevent]
+pub struct TokenOracleSetEvent {
+    pub admin: Address,
+    pub token: Address,
+    pub oracle: Address,
+    pub timestamp: u64,
+}
+
+pub fn publish_token_oracle_set_event(
+    env: &Env,
+    admin: Address,
+    token: Address,
+    oracle: Address,
+    timestamp: u64,
+) {
+    TokenOracleSetEvent {
+        admin,
+        token,
+        oracle,
+        timestamp,
+    }
+    .publish(env);
+}
+
+#[contractevent]
 pub struct ContractUpgradedEvent {
     pub new_wasm_hash: BytesN<32>,
     pub timestamp: u64,
@@ -422,6 +467,63 @@ pub fn publish_invoice_paid_event(
 }
 
 #[contractevent]
+pub struct FiatInvoicePricedEvent {
+    pub invoice_id: u64,
+    pub token: Address,
+    pub resolved_amount: i128,
+    pub timestamp: u64,
+}
+
+pub fn publish_fiat_invoice_priced_event(
+    env: &Env,
+    invoice_id: u64,
+    token: Address,
+    resolved_amount: i128,
+    timestamp: u64,
+) {
+    FiatInvoicePricedEvent {
+        invoice_id,
+        token,
+        resolved_amount,
+        timestamp,
+    }
+    .publish(env);
+}
+
+#[contractevent]
+pub struct PaymentSplitRoutedEvent {
+    pub invoice_id: u64,
+    pub merchant_account: Address,
+    pub platform_account: Address,
+    pub merchant_amount: i128,
+    pub platform_amount: i128,
+    pub token: Address,
+    pub timestamp: u64,
+}
+
+pub fn publish_payment_split_routed_event(
+    env: &Env,
+    invoice_id: u64,
+    merchant_account: Address,
+    platform_account: Address,
+    merchant_amount: i128,
+    platform_amount: i128,
+    token: Address,
+    timestamp: u64,
+) {
+    PaymentSplitRoutedEvent {
+        invoice_id,
+        merchant_account,
+        platform_account,
+        merchant_amount,
+        platform_amount,
+        token,
+        timestamp,
+    }
+    .publish(env);
+}
+
+#[contractevent]
 pub struct InvoiceCancelledEvent {
     pub invoice_id: u64,
     pub merchant: Address,
@@ -485,6 +587,27 @@ pub fn publish_nonce_invalidated_event(
     NonceInvalidatedEvent {
         merchant,
         nonce,
+        timestamp,
+    }
+    .publish(env);
+}
+
+#[contractevent]
+pub struct CrossChainBridgePlaceholderEvent {
+    pub caller: Address,
+    pub payload: crate::types::CrossChainBridgePayload,
+    pub timestamp: u64,
+}
+
+pub fn publish_cross_chain_bridge_placeholder_event(
+    env: &Env,
+    caller: Address,
+    payload: crate::types::CrossChainBridgePayload,
+    timestamp: u64,
+) {
+    CrossChainBridgePlaceholderEvent {
+        caller,
+        payload,
         timestamp,
     }
     .publish(env);

--- a/contracts/shade/src/interface.rs
+++ b/contracts/shade/src/interface.rs
@@ -1,5 +1,6 @@
 use crate::types::{
-    Invoice, InvoiceFilter, Merchant, MerchantFilter, PendingFee, Role, Subscription,
+    CrossChainBridgePayload, Invoice, InvoiceFilter, Merchant, MerchantAnalytics,
+    MerchantAnalyticsSummary, MerchantFilter, OracleConfig, PendingFee, Role, Subscription,
     SubscriptionPlan,
 };
 use soroban_sdk::{contracttrait, Address, BytesN, Env, String, Vec};
@@ -15,6 +16,10 @@ pub trait ShadeTrait {
     fn set_account_wasm_hash(env: Env, admin: Address, wasm_hash: soroban_sdk::BytesN<32>);
     fn set_fee(env: Env, admin: Address, token: Address, fee: i128);
     fn get_fee(env: Env, token: Address) -> i128;
+    fn set_platform_account(env: Env, admin: Address, account: Address);
+    fn get_platform_account(env: Env) -> Address;
+    fn set_token_oracle(env: Env, admin: Address, token: Address, oracle: OracleConfig);
+    fn get_token_oracle(env: Env, token: Address) -> OracleConfig;
     fn propose_fee(env: Env, admin: Address, token: Address, fee: i128);
     fn execute_fee(env: Env, admin: Address, token: Address);
     fn get_pending_fee(env: Env, token: Address) -> PendingFee;
@@ -31,6 +36,16 @@ pub trait ShadeTrait {
         merchant: Address,
         description: String,
         amount: i128,
+        token: Address,
+        expires_at: Option<u64>,
+    ) -> u64;
+    fn create_fiat_invoice(
+        env: Env,
+        merchant: Address,
+        description: String,
+        fiat_amount: i128,
+        fiat_currency: String,
+        fiat_decimals: u32,
         token: Address,
         expires_at: Option<u64>,
     ) -> u64;
@@ -55,6 +70,7 @@ pub trait ShadeTrait {
         signature: BytesN<64>,
     ) -> u64;
     fn get_invoice(env: Env, invoice_id: u64) -> Invoice;
+    fn resolve_invoice_amount(env: Env, invoice_id: u64) -> i128;
     fn refund_invoice(env: Env, merchant: Address, invoice_id: u64);
     fn set_merchant_key(env: Env, merchant: Address, key: BytesN<32>);
     fn get_merchant_key(env: Env, merchant: Address) -> BytesN<32>;
@@ -75,6 +91,8 @@ pub trait ShadeTrait {
     );
     fn calculate_fee(env: Env, merchant: Address, token: Address, amount: i128) -> i128;
     fn get_merchant_volume(env: Env, merchant: Address, token: Address) -> i128;
+    fn get_merchant_analytics(env: Env, merchant: Address, token: Address) -> MerchantAnalytics;
+    fn get_merchant_analytics_summary(env: Env, merchant: Address) -> MerchantAnalyticsSummary;
     fn set_merchant_account(env: Env, merchant: Address, account: Address);
     fn get_merchant_account(env: Env, merchant_id: u64) -> Address;
     fn pay_invoice(env: Env, payer: Address, invoice_id: u64);
@@ -134,4 +152,10 @@ pub trait ShadeTrait {
 
     /// Cancel a subscription. Either the customer or the merchant may call this.
     fn cancel_subscription(env: Env, caller: Address, subscription_id: u64);
+
+    fn emit_cross_chain_bridge_placeholder(
+        env: Env,
+        caller: Address,
+        payload: CrossChainBridgePayload,
+    );
 }

--- a/contracts/shade/src/shade.rs
+++ b/contracts/shade/src/shade.rs
@@ -7,7 +7,8 @@ use crate::errors::ContractError;
 use crate::events;
 use crate::interface::ShadeTrait;
 use crate::types::{
-    ContractInfo, DataKey, Invoice, InvoiceFilter, Merchant, MerchantFilter, PendingFee, Role,
+    ContractInfo, CrossChainBridgePayload, DataKey, Invoice, InvoiceFilter, Merchant,
+    MerchantAnalytics, MerchantAnalyticsSummary, MerchantFilter, OracleConfig, PendingFee, Role,
     Subscription, SubscriptionPlan,
 };
 use soroban_sdk::{contract, contractimpl, panic_with_error, Address, BytesN, Env, String, Vec};
@@ -26,6 +27,9 @@ impl ShadeTrait for Shade {
             timestamp: env.ledger().timestamp(),
         };
         env.storage().persistent().set(&DataKey::Admin, &admin);
+        env.storage()
+            .persistent()
+            .set(&DataKey::PlatformAccount, &admin);
         env.storage()
             .persistent()
             .set(&DataKey::ContractInfo, &contract_info);
@@ -66,6 +70,24 @@ impl ShadeTrait for Shade {
 
     fn get_fee(env: Env, token: Address) -> i128 {
         admin_component::get_fee(&env, &token)
+    }
+
+    fn set_platform_account(env: Env, admin: Address, account: Address) {
+        pausable_component::assert_not_paused(&env);
+        admin_component::set_platform_account(&env, &admin, &account);
+    }
+
+    fn get_platform_account(env: Env) -> Address {
+        admin_component::get_platform_account(&env)
+    }
+
+    fn set_token_oracle(env: Env, admin: Address, token: Address, oracle: OracleConfig) {
+        pausable_component::assert_not_paused(&env);
+        admin_component::set_token_oracle(&env, &admin, &token, &oracle);
+    }
+
+    fn get_token_oracle(env: Env, token: Address) -> OracleConfig {
+        admin_component::get_token_oracle(&env, &token)
     }
 
     fn propose_fee(env: Env, admin: Address, token: Address, fee: i128) {
@@ -127,6 +149,29 @@ impl ShadeTrait for Shade {
         invoice_component::create_invoice(&env, &merchant, &description, amount, &token, expires_at)
     }
 
+    fn create_fiat_invoice(
+        env: Env,
+        merchant: Address,
+        description: String,
+        fiat_amount: i128,
+        fiat_currency: String,
+        fiat_decimals: u32,
+        token: Address,
+        expires_at: Option<u64>,
+    ) -> u64 {
+        pausable_component::assert_not_paused(&env);
+        invoice_component::create_fiat_invoice(
+            &env,
+            &merchant,
+            &description,
+            fiat_amount,
+            &fiat_currency,
+            fiat_decimals,
+            &token,
+            expires_at,
+        )
+    }
+
     fn create_invoice_draft(
         env: Env,
         merchant: Address,
@@ -177,6 +222,10 @@ impl ShadeTrait for Shade {
 
     fn get_invoice(env: Env, invoice_id: u64) -> Invoice {
         invoice_component::get_invoice(&env, invoice_id)
+    }
+
+    fn resolve_invoice_amount(env: Env, invoice_id: u64) -> i128 {
+        invoice_component::resolve_invoice_amount(&env, invoice_id)
     }
 
     fn refund_invoice(env: Env, merchant: Address, invoice_id: u64) {
@@ -244,6 +293,14 @@ impl ShadeTrait for Shade {
 
     fn get_merchant_volume(env: Env, merchant: Address, token: Address) -> i128 {
         admin_component::get_merchant_volume(&env, &merchant, &token)
+    }
+
+    fn get_merchant_analytics(env: Env, merchant: Address, token: Address) -> MerchantAnalytics {
+        admin_component::get_merchant_analytics(&env, &merchant, &token)
+    }
+
+    fn get_merchant_analytics_summary(env: Env, merchant: Address) -> MerchantAnalyticsSummary {
+        admin_component::get_merchant_analytics_summary(&env, &merchant)
     }
 
     fn set_merchant_account(env: Env, merchant: Address, account: Address) {
@@ -353,5 +410,20 @@ impl ShadeTrait for Shade {
 
     fn is_token_accepted_for_merchant(env: Env, merchant: Address, token: Address) -> bool {
         merchant_component::is_token_accepted_for_merchant(&env, &merchant, &token)
+    }
+
+    fn emit_cross_chain_bridge_placeholder(
+        env: Env,
+        caller: Address,
+        payload: CrossChainBridgePayload,
+    ) {
+        pausable_component::assert_not_paused(&env);
+        caller.require_auth();
+        events::publish_cross_chain_bridge_placeholder_event(
+            &env,
+            caller,
+            payload,
+            env.ledger().timestamp(),
+        );
     }
 }

--- a/contracts/shade/src/types.rs
+++ b/contracts/shade/src/types.rs
@@ -1,4 +1,4 @@
-use soroban_sdk::{contracttype, Address, BytesN};
+use soroban_sdk::{contracttype, Address, BytesN, String};
 
 #[contracttype]
 pub enum DataKey {
@@ -32,6 +32,10 @@ pub enum DataKey {
     PendingTokenFee(Address),
     // --- Fee discount system ---
     MerchantVolume(Address, Address),
+    MerchantAnalytics(Address, Address),
+    MerchantAnalyticsSummary(Address),
+    PlatformAccount,
+    TokenOracle(Address),
 }
 
 #[contracttype]
@@ -67,6 +71,8 @@ pub struct Invoice {
     pub amount_paid: i128,
     pub amount_refunded: i128,
     pub expires_at: Option<u64>,
+    pub pricing_mode: InvoicePricingMode,
+    pub fiat_pricing: Option<FiatPricing>,
 }
 
 #[contracttype]
@@ -80,6 +86,22 @@ pub enum InvoiceStatus {
     PartiallyRefunded = 4,
     PartiallyPaid = 5,
     Draft = 6,
+}
+
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum InvoicePricingMode {
+    FixedCrypto = 0,
+    FixedFiat = 1,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FiatPricing {
+    pub currency: String,
+    pub amount: i128,
+    pub decimals: u32,
 }
 
 #[contracttype]
@@ -113,6 +135,49 @@ pub enum Role {
 pub struct VolumeDiscount {
     pub min_volume: i128,
     pub discount_bps: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OracleConfig {
+    pub contract: Address,
+    pub price_decimals: u32,
+    pub token_decimals: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MerchantAnalytics {
+    pub merchant: Address,
+    pub token: Address,
+    pub total_volume: i128,
+    pub total_fees: i128,
+    pub transaction_count: u64,
+    pub last_updated: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct MerchantAnalyticsSummary {
+    pub merchant: Address,
+    pub total_volume: i128,
+    pub total_fees: i128,
+    pub transaction_count: u64,
+    pub last_updated: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CrossChainBridgePayload {
+    pub invoice_id: u64,
+    pub merchant: Address,
+    pub payer: Option<Address>,
+    pub source_chain: String,
+    pub destination_chain: String,
+    pub token: Address,
+    pub amount: i128,
+    pub destination_recipient: String,
+    pub memo: Option<String>,
 }
 
 // ── Time-locked fee update ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
This PR adds oracle-backed fiat invoice pricing, merchant analytics aggregation, platform fee split routing, and cross-chain bridge placeholders to the Shade contract.

## Covers
- #198 Integrate Price Oracle for Fiat-to-Crypto Dynamic Pricing
- #184 Implement Comprehensive Analytics Aggregation Logic
- #202 Implement Cross-chain Payment Proxy Placeholders
- #190 Implement Payment Routing for Platform Splits

## Notes
- No tests or build verification were run for this branch by request.
- Fiat invoice settlement assumes the configured oracle exposes get_price(token, quote_currency) -> i128.
- Platform fees now route directly to the configured platform account.

Closes #198
Closes #184
Closes #202
Closes #190