### PR TITLE
feat(shade): event ticketing — payment, minting, royalty resale

### DIFF
--- a/contracts/shade/src/components/admin.rs
+++ b/contracts/shade/src/components/admin.rs
@@ -318,22 +318,34 @@ fn record_token_payment(env: &Env, token: &Address, volume_amount: i128, fee_amo
 }
 
 pub fn get_token_dominance_metrics(env: &Env, tokens: &Vec<Address>) -> Vec<(Address, i128)> {
-    let mut token_volumes_native: std::vec::Vec<(Address, i128)> = std::vec::Vec::new();
-    
-    // Calculate total volume across all tokens
+    // Build the (token, volume) list in a soroban Vec. We avoid `std::vec::Vec`
+    // because the contract is `#![no_std]`.
+    let mut result: Vec<(Address, i128)> = Vec::new(env);
     for token in tokens.iter() {
         let volume = get_token_volume(env, &token);
-        token_volumes_native.push((token, volume));
+        result.push_back((token, volume));
     }
-    
-    // Sort by volume in descending order
-    token_volumes_native.sort_by(|a, b| b.1.cmp(&a.1));
-    
-    let mut result = Vec::new(env);
-    for item in token_volumes_native {
-        result.push_back(item);
+
+    // Insertion sort by volume descending. n is small (one entry per accepted
+    // token) so quadratic cost is fine and avoids allocator dependencies.
+    let n = result.len();
+    let mut i: u32 = 1;
+    while i < n {
+        let mut j: u32 = i;
+        while j > 0 {
+            let prev = result.get_unchecked(j - 1);
+            let curr = result.get_unchecked(j);
+            if curr.1 > prev.1 {
+                result.set(j - 1, curr);
+                result.set(j, prev);
+                j -= 1;
+            } else {
+                break;
+            }
+        }
+        i += 1;
     }
-    
+
     result
 }
 

--- a/contracts/shade/src/components/event.rs
+++ b/contracts/shade/src/components/event.rs
@@ -1,7 +1,12 @@
-use crate::components::{core, merchant};
+use crate::components::{admin, merchant};
 use crate::errors::ContractError;
-use crate::types::{DataKey, Event, Merchant};
-use soroban_sdk::{panic_with_error, Address, Env, String};
+use crate::events;
+use crate::types::{DataKey, Event, Merchant, Ticket};
+use soroban_sdk::{panic_with_error, token, Address, Env, String, Vec};
+
+const MAX_BPS: u32 = 10_000;
+
+// ── Event creation (Issue #246) ───────────────────────────────────────────────
 
 pub fn create_event(
     env: &Env,
@@ -10,17 +15,35 @@ pub fn create_event(
     ticket_price: &i128,
     token: &Address,
     capacity: &u32,
+    event_date: &u64,
+    royalty_bps: &u32,
 ) -> u64 {
     merchant_addr.require_auth();
 
-    let merchant_id = crate::components::merchant::get_merchant_id(env, merchant_addr);
-    let merchant: Merchant = env
+    if *ticket_price <= 0 {
+        panic_with_error!(env, ContractError::InvalidAmount);
+    }
+    if *capacity == 0 {
+        panic_with_error!(env, ContractError::InvalidCapacity);
+    }
+    if *royalty_bps > MAX_BPS {
+        panic_with_error!(env, ContractError::InvalidRoyaltyBps);
+    }
+    if *event_date < env.ledger().timestamp() {
+        panic_with_error!(env, ContractError::InvalidEventDate);
+    }
+    if !admin::is_accepted_token(env, token) {
+        panic_with_error!(env, ContractError::TokenNotAccepted);
+    }
+
+    let merchant_id = merchant::get_merchant_id(env, merchant_addr);
+    let merchant_record: Merchant = env
         .storage()
         .persistent()
         .get(&DataKey::Merchant(merchant_id))
-        .unwrap();
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::MerchantNotFound));
 
-    if !merchant.active {
+    if !merchant_record.active {
         panic_with_error!(env, ContractError::MerchantNotActive);
     }
 
@@ -40,37 +63,266 @@ pub fn create_event(
         capacity: *capacity,
         sold: 0,
         date: env.ledger().timestamp(),
+        event_date: *event_date,
+        royalty_bps: *royalty_bps,
     };
 
     env.storage().persistent().set(&DataKey::Event(id), &event);
     env.storage().persistent().set(&DataKey::EventCount, &id);
+    env.storage()
+        .persistent()
+        .set(&DataKey::EventTickets(id), &Vec::<u64>::new(env));
+
+    events::publish_event_created_event(
+        env,
+        id,
+        merchant_addr.clone(),
+        merchant_id,
+        name.clone(),
+        *ticket_price,
+        token.clone(),
+        *capacity,
+        *event_date,
+        *royalty_bps,
+        env.ledger().timestamp(),
+    );
 
     id
-}
-
-pub fn purchase_ticket(env: &Env, event_id: &u64, buyer: &Address) {
-    buyer.require_auth();
-
-    let mut event: Event = env
-        .storage()
-        .persistent()
-        .get(&DataKey::Event(*event_id))
-        .unwrap_or_else(|| panic_with_error!(env, ContractError::InvoiceNotFound)); // Using InvoiceNotFound as a generic "Not Found" for now
-
-    if event.sold >= event.capacity {
-        panic_with_error!(env, ContractError::InvalidAmount); // Should use a proper error, but let's stick to existing ones for now
-    }
-
-    // Transfer tokens (this is a simplified version, usually we'd use the payment component)
-    // For the sake of this task, let's just increment the sold count.
-    
-    event.sold += 1;
-    env.storage().persistent().set(&DataKey::Event(*event_id), &event);
 }
 
 pub fn get_event(env: &Env, event_id: &u64) -> Event {
     env.storage()
         .persistent()
         .get(&DataKey::Event(*event_id))
-        .unwrap()
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::EventNotFound))
+}
+
+// ── Ticket purchase via Shade payment (Issues #247 + #248) ────────────────────
+
+pub fn purchase_ticket(env: &Env, event_id: &u64, buyer: &Address) -> u64 {
+    buyer.require_auth();
+
+    let mut event = get_event(env, event_id);
+
+    if event.sold >= event.capacity {
+        panic_with_error!(env, ContractError::EventSoldOut);
+    }
+
+    // Re-validate token in case admin removed it after event creation.
+    if !admin::is_accepted_token(env, &event.token) {
+        panic_with_error!(env, ContractError::TokenNotAccepted);
+    }
+
+    let merchant_address = merchant_id_to_address(env, event.merchant_id);
+    let merchant_account = merchant::get_merchant_account(env, event.merchant_id);
+    let platform_account = admin::get_platform_account(env);
+
+    let amount = event.ticket_price;
+    let fee = admin::calculate_fee(env, &merchant_address, &event.token, amount);
+    if fee < 0 || fee >= amount {
+        panic_with_error!(env, ContractError::InvalidAmount);
+    }
+    let merchant_amount = amount - fee;
+
+    let token_client = token::TokenClient::new(env, &event.token);
+    token_client.transfer(buyer, &merchant_account, &merchant_amount);
+    if fee > 0 {
+        token_client.transfer(buyer, &platform_account, &fee);
+    }
+
+    admin::record_merchant_payment(env, &merchant_address, &event.token, amount, fee);
+
+    let new_ticket_id = env
+        .storage()
+        .persistent()
+        .get(&DataKey::TicketCount)
+        .unwrap_or(0u64)
+        + 1;
+
+    let ticket = Ticket {
+        id: new_ticket_id,
+        event_id: *event_id,
+        owner: buyer.clone(),
+        minted_at: env.ledger().timestamp(),
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::Ticket(new_ticket_id), &ticket);
+    env.storage()
+        .persistent()
+        .set(&DataKey::TicketCount, &new_ticket_id);
+
+    let mut event_tickets: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::EventTickets(*event_id))
+        .unwrap_or_else(|| Vec::new(env));
+    event_tickets.push_back(new_ticket_id);
+    env.storage()
+        .persistent()
+        .set(&DataKey::EventTickets(*event_id), &event_tickets);
+
+    add_user_ticket(env, buyer, new_ticket_id);
+
+    event.sold += 1;
+    env.storage()
+        .persistent()
+        .set(&DataKey::Event(*event_id), &event);
+
+    events::publish_ticket_purchased_event(
+        env,
+        new_ticket_id,
+        *event_id,
+        event.merchant_id,
+        buyer.clone(),
+        amount,
+        fee,
+        merchant_amount,
+        event.token.clone(),
+        env.ledger().timestamp(),
+    );
+
+    new_ticket_id
+}
+
+// ── Resale with royalty (Issue #254) ──────────────────────────────────────────
+
+pub fn resell_ticket(
+    env: &Env,
+    seller: &Address,
+    buyer: &Address,
+    ticket_id: u64,
+    resale_price: i128,
+) {
+    seller.require_auth();
+
+    if resale_price <= 0 {
+        panic_with_error!(env, ContractError::InvalidResalePrice);
+    }
+
+    let mut ticket: Ticket = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Ticket(ticket_id))
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::TicketNotFound));
+
+    if ticket.owner != *seller {
+        panic_with_error!(env, ContractError::NotTicketOwner);
+    }
+    if seller == buyer {
+        panic_with_error!(env, ContractError::NotAuthorized);
+    }
+
+    let event = get_event(env, &ticket.event_id);
+
+    if !admin::is_accepted_token(env, &event.token) {
+        panic_with_error!(env, ContractError::TokenNotAccepted);
+    }
+
+    let royalty = bps_of(resale_price, event.royalty_bps)
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::InvalidAmount));
+    if royalty < 0 || royalty > resale_price {
+        panic_with_error!(env, ContractError::InvalidAmount);
+    }
+    let seller_proceeds = resale_price - royalty;
+
+    let merchant_account = merchant::get_merchant_account(env, event.merchant_id);
+    let token_client = token::TokenClient::new(env, &event.token);
+
+    if seller_proceeds > 0 {
+        token_client.transfer(buyer, seller, &seller_proceeds);
+    }
+    if royalty > 0 {
+        token_client.transfer(buyer, &merchant_account, &royalty);
+    }
+
+    let prev_owner = ticket.owner.clone();
+    ticket.owner = buyer.clone();
+    env.storage()
+        .persistent()
+        .set(&DataKey::Ticket(ticket_id), &ticket);
+
+    remove_user_ticket(env, &prev_owner, ticket_id);
+    add_user_ticket(env, buyer, ticket_id);
+
+    events::publish_ticket_resold_event(
+        env,
+        ticket_id,
+        ticket.event_id,
+        event.merchant_id,
+        prev_owner,
+        buyer.clone(),
+        resale_price,
+        royalty,
+        seller_proceeds,
+        event.token.clone(),
+        env.ledger().timestamp(),
+    );
+}
+
+pub fn get_ticket(env: &Env, ticket_id: u64) -> Ticket {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Ticket(ticket_id))
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::TicketNotFound))
+}
+
+pub fn get_event_tickets(env: &Env, event_id: u64) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::EventTickets(event_id))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+pub fn get_user_tickets(env: &Env, user: &Address) -> Vec<u64> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::UserTickets(user.clone()))
+        .unwrap_or_else(|| Vec::new(env))
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+fn merchant_id_to_address(env: &Env, merchant_id: u64) -> Address {
+    let m: Merchant = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Merchant(merchant_id))
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::MerchantNotFound));
+    m.address
+}
+
+fn add_user_ticket(env: &Env, user: &Address, ticket_id: u64) {
+    let key = DataKey::UserTickets(user.clone());
+    let mut list: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env));
+    list.push_back(ticket_id);
+    env.storage().persistent().set(&key, &list);
+}
+
+fn remove_user_ticket(env: &Env, user: &Address, ticket_id: u64) {
+    let key = DataKey::UserTickets(user.clone());
+    let list: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&key)
+        .unwrap_or_else(|| Vec::new(env));
+    let mut new_list: Vec<u64> = Vec::new(env);
+    for id in list.iter() {
+        if id != ticket_id {
+            new_list.push_back(id);
+        }
+    }
+    env.storage().persistent().set(&key, &new_list);
+}
+
+// `value * bps / 10_000` with checked multiplication to catch overflow on the
+// intermediate product before it would silently wrap.
+fn bps_of(value: i128, bps: u32) -> Option<i128> {
+    let scaled = value.checked_mul(bps as i128)?;
+    Some(scaled / MAX_BPS as i128)
 }

--- a/contracts/shade/src/errors.rs
+++ b/contracts/shade/src/errors.rs
@@ -44,4 +44,13 @@ pub enum ContractError {
     NoPendingFeeUpdate = 43,
     InvalidSwapPath = 44,
     InvalidSlippage = 45,
+    EventNotFound = 46,
+    EventSoldOut = 47,
+    InvalidCapacity = 48,
+    InvalidEventDate = 49,
+    InvalidRoyaltyBps = 50,
+    TicketNotFound = 51,
+    NotTicketOwner = 52,
+    TicketEventMismatch = 53,
+    InvalidResalePrice = 54,
 }

--- a/contracts/shade/src/events.rs
+++ b/contracts/shade/src/events.rs
@@ -876,3 +876,131 @@ pub fn publish_admin_transfer_accepted_event(
     }
     .publish(env);
 }
+
+// ── Event ticketing system ────────────────────────────────────────────────────
+
+#[contractevent]
+pub struct EventCreatedEvent {
+    pub event_id: u64,
+    pub merchant: Address,
+    pub merchant_id: u64,
+    pub name: String,
+    pub ticket_price: i128,
+    pub token: Address,
+    pub capacity: u32,
+    pub event_date: u64,
+    pub royalty_bps: u32,
+    pub timestamp: u64,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn publish_event_created_event(
+    env: &Env,
+    event_id: u64,
+    merchant: Address,
+    merchant_id: u64,
+    name: String,
+    ticket_price: i128,
+    token: Address,
+    capacity: u32,
+    event_date: u64,
+    royalty_bps: u32,
+    timestamp: u64,
+) {
+    EventCreatedEvent {
+        event_id,
+        merchant,
+        merchant_id,
+        name,
+        ticket_price,
+        token,
+        capacity,
+        event_date,
+        royalty_bps,
+        timestamp,
+    }
+    .publish(env);
+}
+
+#[contractevent]
+pub struct TicketPurchasedEvent {
+    pub ticket_id: u64,
+    pub event_id: u64,
+    pub merchant_id: u64,
+    pub buyer: Address,
+    pub amount: i128,
+    pub fee: i128,
+    pub merchant_amount: i128,
+    pub token: Address,
+    pub timestamp: u64,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn publish_ticket_purchased_event(
+    env: &Env,
+    ticket_id: u64,
+    event_id: u64,
+    merchant_id: u64,
+    buyer: Address,
+    amount: i128,
+    fee: i128,
+    merchant_amount: i128,
+    token: Address,
+    timestamp: u64,
+) {
+    TicketPurchasedEvent {
+        ticket_id,
+        event_id,
+        merchant_id,
+        buyer,
+        amount,
+        fee,
+        merchant_amount,
+        token,
+        timestamp,
+    }
+    .publish(env);
+}
+
+#[contractevent]
+pub struct TicketResoldEvent {
+    pub ticket_id: u64,
+    pub event_id: u64,
+    pub merchant_id: u64,
+    pub seller: Address,
+    pub buyer: Address,
+    pub resale_price: i128,
+    pub royalty: i128,
+    pub seller_proceeds: i128,
+    pub token: Address,
+    pub timestamp: u64,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn publish_ticket_resold_event(
+    env: &Env,
+    ticket_id: u64,
+    event_id: u64,
+    merchant_id: u64,
+    seller: Address,
+    buyer: Address,
+    resale_price: i128,
+    royalty: i128,
+    seller_proceeds: i128,
+    token: Address,
+    timestamp: u64,
+) {
+    TicketResoldEvent {
+        ticket_id,
+        event_id,
+        merchant_id,
+        seller,
+        buyer,
+        resale_price,
+        royalty,
+        seller_proceeds,
+        token,
+        timestamp,
+    }
+    .publish(env);
+}

--- a/contracts/shade/src/interface.rs
+++ b/contracts/shade/src/interface.rs
@@ -1,7 +1,7 @@
 use crate::types::{
     CrossChainBridgePayload, Event, Invoice, InvoiceFilter, Merchant, MerchantAnalytics,
-    MerchantAnalyticsSummary, MerchantFilter, OracleConfig, PendingFee, Role, Subscription,
-    SubscriptionPlan, TokenAnalytics, Transaction
+    MerchantAnalyticsSummary, MerchantFilter, OracleConfig, PaymentPayload, PendingFee, Role,
+    Subscription, SubscriptionPlan, Ticket, TokenAnalytics, Transaction
 };
 use soroban_sdk::{contracttrait, Address, BytesN, Env, String, Vec};
 
@@ -167,7 +167,8 @@ pub trait ShadeTrait {
         payload: CrossChainBridgePayload,
     );
 
-    // --- Event system ---
+    // --- Event ticketing system ---
+    #[allow(clippy::too_many_arguments)]
     fn create_event(
         env: Env,
         merchant: Address,
@@ -175,9 +176,21 @@ pub trait ShadeTrait {
         ticket_price: i128,
         token: Address,
         capacity: u32,
+        event_date: u64,
+        royalty_bps: u32,
     ) -> u64;
-    fn purchase_ticket(env: Env, event_id: u64, buyer: Address);
+    fn purchase_ticket(env: Env, event_id: u64, buyer: Address) -> u64;
+    fn resell_ticket(
+        env: Env,
+        seller: Address,
+        buyer: Address,
+        ticket_id: u64,
+        resale_price: i128,
+    );
     fn get_event(env: Env, event_id: u64) -> Event;
+    fn get_ticket(env: Env, ticket_id: u64) -> Ticket;
+    fn get_event_tickets(env: Env, event_id: u64) -> Vec<u64>;
+    fn get_user_tickets(env: Env, user: Address) -> Vec<u64>;
 
     // ── Token analytics ────────────────────────────────────────────────────────
 

--- a/contracts/shade/src/shade.rs
+++ b/contracts/shade/src/shade.rs
@@ -2,7 +2,7 @@ use crate::components::{
     access_control as access_control_component, admin as admin_component, core as core_component,
     invoice as invoice_component, merchant as merchant_component, pausable as pausable_component,
     subscription as subscription_component, upgrade as upgrade_component,
-    history as history_component, payment as payment_component,
+    history as history_component,
 };
 use crate::errors::ContractError;
 use crate::events;
@@ -10,8 +10,7 @@ use crate::interface::ShadeTrait;
 use crate::types::{
     ContractInfo, CrossChainBridgePayload, DataKey, Event, Invoice, InvoiceFilter, Merchant,
     MerchantAnalytics, MerchantAnalyticsSummary, MerchantFilter, OracleConfig, PaymentPayload,
-    PaymentRoute, PendingFee, Role, Subscription, SubscriptionPlan, SwapRoute, TokenAnalytics,
-    Transaction
+    PendingFee, Role, Subscription, SubscriptionPlan, Ticket, TokenAnalytics, Transaction,
 };
 use soroban_sdk::{contract, contractimpl, panic_with_error, Address, BytesN, Env, String, Vec};
 
@@ -296,21 +295,6 @@ impl ShadeTrait for Shade {
     fn get_merchant_volume(env: Env, merchant: Address, token: Address) -> i128 {
         admin_component::get_merchant_volume(&env, &merchant, &token)
     }
-    fn get_daily_volume(env: Env, token: Address) -> i128 {
-        admin_component::get_daily_volume(&env, &token)
-    }
-
-    fn get_weekly_volume(env: Env, token: Address) -> i128 {
-        admin_component::get_weekly_volume(&env, &token)
-    }
-
-    fn get_merchant_daily_volume(env: Env, merchant: Address, token: Address) -> i128 {
-        admin_component::get_merchant_daily_volume(&env, &merchant, &token)
-    }
-
-    fn get_merchant_weekly_volume(env: Env, merchant: Address, token: Address) -> i128 {
-        admin_component::get_merchant_weekly_volume(&env, &merchant, &token)
-    }
 
     fn get_merchant_analytics(env: Env, merchant: Address, token: Address) -> MerchantAnalytics {
         admin_component::get_merchant_analytics(&env, &merchant, &token)
@@ -461,7 +445,8 @@ impl ShadeTrait for Shade {
         );
     }
 
-    // --- Event system ---
+    // --- Event ticketing system ---
+    #[allow(clippy::too_many_arguments)]
     fn create_event(
         env: Env,
         merchant: Address,
@@ -469,18 +454,52 @@ impl ShadeTrait for Shade {
         ticket_price: i128,
         token: Address,
         capacity: u32,
+        event_date: u64,
+        royalty_bps: u32,
     ) -> u64 {
         pausable_component::assert_not_paused(&env);
-        crate::components::event::create_event(&env, &merchant, &name, &ticket_price, &token, &capacity)
+        crate::components::event::create_event(
+            &env,
+            &merchant,
+            &name,
+            &ticket_price,
+            &token,
+            &capacity,
+            &event_date,
+            &royalty_bps,
+        )
     }
 
-    fn purchase_ticket(env: Env, event_id: u64, buyer: Address) {
+    fn purchase_ticket(env: Env, event_id: u64, buyer: Address) -> u64 {
         pausable_component::assert_not_paused(&env);
-        crate::components::event::purchase_ticket(&env, &event_id, &buyer);
+        crate::components::event::purchase_ticket(&env, &event_id, &buyer)
     }
 
-    fn get_event(env: Env, event_id: u64) -> crate::types::Event {
+    fn resell_ticket(
+        env: Env,
+        seller: Address,
+        buyer: Address,
+        ticket_id: u64,
+        resale_price: i128,
+    ) {
+        pausable_component::assert_not_paused(&env);
+        crate::components::event::resell_ticket(&env, &seller, &buyer, ticket_id, resale_price);
+    }
+
+    fn get_event(env: Env, event_id: u64) -> Event {
         crate::components::event::get_event(&env, &event_id)
+    }
+
+    fn get_ticket(env: Env, ticket_id: u64) -> Ticket {
+        crate::components::event::get_ticket(&env, ticket_id)
+    }
+
+    fn get_event_tickets(env: Env, event_id: u64) -> Vec<u64> {
+        crate::components::event::get_event_tickets(&env, event_id)
+    }
+
+    fn get_user_tickets(env: Env, user: Address) -> Vec<u64> {
+        crate::components::event::get_user_tickets(&env, &user)
     }
 
     fn get_token_analytics(env: Env, token: Address) -> TokenAnalytics {

--- a/contracts/shade/src/tests/test_event_tickets.rs
+++ b/contracts/shade/src/tests/test_event_tickets.rs
@@ -1,81 +1,434 @@
 #![cfg(test)]
 
 use crate::shade::{Shade, ShadeClient};
-use soroban_sdk::testutils::{Address as _};
-use soroban_sdk::{Address, Env, String};
+use soroban_sdk::testutils::{Address as _, Ledger as _, MockAuth, MockAuthInvoke};
+use soroban_sdk::token::{StellarAssetClient, TokenClient};
+use soroban_sdk::{Address, Env, IntoVal, String};
 
-fn setup_test() -> (Env, ShadeClient<'static>, Address, Address) {
+const TOKEN_INITIAL_BALANCE: i128 = 1_000_000;
+
+struct Fixture<'a> {
+    env: Env,
+    client: ShadeClient<'a>,
+    admin: Address,
+    token: Address,
+}
+
+fn setup() -> Fixture<'static> {
     let env = Env::default();
     env.mock_all_auths();
     let contract_id = env.register(Shade, ());
     let client = ShadeClient::new(&env, &contract_id);
+
     let admin = Address::generate(&env);
     client.initialize(&admin);
-    (env, client, contract_id, admin)
+
+    let token_admin = Address::generate(&env);
+    let token_address = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+    client.add_accepted_token(&admin, &token_address);
+
+    Fixture {
+        env,
+        client,
+        admin,
+        token: token_address,
+    }
 }
 
-fn create_test_token(env: &Env) -> Address {
-    let token_admin = Address::generate(env);
-    env.register_stellar_asset_contract_v2(token_admin)
-        .address()
+fn fund(env: &Env, token: &Address, to: &Address, amount: i128) {
+    let asset_client = StellarAssetClient::new(env, token);
+    let issuer = asset_client.admin();
+    asset_client
+        .mock_auths(&[MockAuth {
+            address: &issuer,
+            invoke: &MockAuthInvoke {
+                contract: token,
+                fn_name: "mint",
+                args: (to.clone(), amount).into_val(env),
+                sub_invokes: &[],
+            },
+        }])
+        .mint(to, &amount);
+}
+
+fn register_merchant_with_account(
+    env: &Env,
+    client: &ShadeClient,
+    token: &Address,
+) -> (Address, Address) {
+    let merchant = Address::generate(env);
+    let merchant_account = Address::generate(env);
+    client.register_merchant(&merchant);
+    client.set_merchant_account(&merchant, &merchant_account);
+    client.set_merchant_accepted_tokens(
+        &merchant,
+        &soroban_sdk::Vec::from_array(env, [token.clone()]),
+    );
+    (merchant, merchant_account)
+}
+
+fn future_date(env: &Env) -> u64 {
+    env.ledger().timestamp() + 86_400
+}
+
+// ── #246 Event creation ───────────────────────────────────────────────────────
+
+#[test]
+fn create_event_stores_all_fields() {
+    let f = setup();
+    let (merchant, _) = register_merchant_with_account(&f.env, &f.client, &f.token);
+
+    let event_date = future_date(&f.env);
+    let event_id = f.client.create_event(
+        &merchant,
+        &String::from_str(&f.env, "Concert"),
+        &500i128,
+        &f.token,
+        &10u32,
+        &event_date,
+        &500u32, // 5% royalty
+    );
+
+    let event = f.client.get_event(&event_id);
+    assert_eq!(event.id, event_id);
+    assert_eq!(event.name, String::from_str(&f.env, "Concert"));
+    assert_eq!(event.ticket_price, 500);
+    assert_eq!(event.token, f.token);
+    assert_eq!(event.capacity, 10);
+    assert_eq!(event.sold, 0);
+    assert_eq!(event.event_date, event_date);
+    assert_eq!(event.royalty_bps, 500);
 }
 
 #[test]
-fn test_event_creation_and_purchase() {
-    let (env, client, _shade_id, admin) = setup_test();
-    let token = create_test_token(&env);
-    client.add_accepted_token(&admin, &token);
-
-    let merchant = Address::generate(&env);
-    client.register_merchant(&merchant);
-
-    let event_id = client.create_event(
+#[should_panic(expected = "Error(Contract, #7)")] // InvalidAmount
+fn create_event_rejects_zero_price() {
+    let f = setup();
+    let (merchant, _) = register_merchant_with_account(&f.env, &f.client, &f.token);
+    f.client.create_event(
         &merchant,
-        &String::from_str(&env, "Concert"),
-        &100,
-        &token,
-        &2, // Capacity 2
+        &String::from_str(&f.env, "X"),
+        &0i128,
+        &f.token,
+        &10u32,
+        &future_date(&f.env),
+        &0u32,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #48)")] // InvalidCapacity
+fn create_event_rejects_zero_capacity() {
+    let f = setup();
+    let (merchant, _) = register_merchant_with_account(&f.env, &f.client, &f.token);
+    f.client.create_event(
+        &merchant,
+        &String::from_str(&f.env, "X"),
+        &100i128,
+        &f.token,
+        &0u32,
+        &future_date(&f.env),
+        &0u32,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #50)")] // InvalidRoyaltyBps
+fn create_event_rejects_royalty_above_100pct() {
+    let f = setup();
+    let (merchant, _) = register_merchant_with_account(&f.env, &f.client, &f.token);
+    f.client.create_event(
+        &merchant,
+        &String::from_str(&f.env, "X"),
+        &100i128,
+        &f.token,
+        &10u32,
+        &future_date(&f.env),
+        &10_001u32,
+    );
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #49)")] // InvalidEventDate
+fn create_event_rejects_past_date() {
+    let f = setup();
+    let (merchant, _) = register_merchant_with_account(&f.env, &f.client, &f.token);
+    // Move ledger forward so 0 is firmly in the past.
+    f.env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+    f.client.create_event(
+        &merchant,
+        &String::from_str(&f.env, "X"),
+        &100i128,
+        &f.token,
+        &10u32,
+        &500u64,
+        &0u32,
+    );
+}
+
+// ── #247 + #248 Payment + minting ────────────────────────────────────────────
+
+#[test]
+fn purchase_ticket_transfers_funds_and_mints() {
+    let f = setup();
+    let (merchant, merchant_account) =
+        register_merchant_with_account(&f.env, &f.client, &f.token);
+    let buyer = Address::generate(&f.env);
+    fund(&f.env, &f.token, &buyer, TOKEN_INITIAL_BALANCE);
+
+    let price: i128 = 500;
+    let event_id = f.client.create_event(
+        &merchant,
+        &String::from_str(&f.env, "Show"),
+        &price,
+        &f.token,
+        &5u32,
+        &future_date(&f.env),
+        &500u32,
     );
 
-    let event = client.get_event(&event_id);
-    assert_eq!(event.name, String::from_str(&env, "Concert"));
-    assert_eq!(event.capacity, 2);
-    assert_eq!(event.sold, 0);
+    let ticket_id = f.client.purchase_ticket(&event_id, &buyer);
 
-    let buyer1 = Address::generate(&env);
-    client.purchase_ticket(&event_id, &buyer1);
-    
-    let event = client.get_event(&event_id);
+    // Ticket exists and is owned by buyer.
+    let ticket = f.client.get_ticket(&ticket_id);
+    assert_eq!(ticket.event_id, event_id);
+    assert_eq!(ticket.owner, buyer);
+
+    // Buyer's tickets list contains the new ticket.
+    let user_tickets = f.client.get_user_tickets(&buyer);
+    assert_eq!(user_tickets.len(), 1);
+    assert_eq!(user_tickets.get_unchecked(0), ticket_id);
+
+    // Sold counter incremented.
+    let event = f.client.get_event(&event_id);
     assert_eq!(event.sold, 1);
 
-    let buyer2 = Address::generate(&env);
-    client.purchase_ticket(&event_id, &buyer2);
-    
-    let event = client.get_event(&event_id);
-    assert_eq!(event.sold, 2);
+    // Funds moved off the buyer.
+    let token_client = TokenClient::new(&f.env, &f.token);
+    assert_eq!(token_client.balance(&buyer), TOKEN_INITIAL_BALANCE - price);
+
+    // Merchant account received `price - fee`. With no fee configured fee is 0,
+    // so the merchant receives the full price.
+    assert_eq!(token_client.balance(&merchant_account), price);
 }
 
 #[test]
-#[should_panic] // Capacity reached
-fn test_event_sold_out() {
-    let (env, client, _shade_id, admin) = setup_test();
-    let token = create_test_token(&env);
-    client.add_accepted_token(&admin, &token);
+fn purchase_ticket_routes_fee_to_platform_when_configured() {
+    let f = setup();
+    let (merchant, merchant_account) =
+        register_merchant_with_account(&f.env, &f.client, &f.token);
+    // 10% platform fee on this token.
+    f.client.set_fee(&f.admin, &f.token, &1_000i128);
 
-    let merchant = Address::generate(&env);
-    client.register_merchant(&merchant);
+    let buyer = Address::generate(&f.env);
+    fund(&f.env, &f.token, &buyer, TOKEN_INITIAL_BALANCE);
 
-    let event_id = client.create_event(
+    let price: i128 = 1_000;
+    let event_id = f.client.create_event(
         &merchant,
-        &String::from_str(&env, "Small Show"),
-        &100,
-        &token,
-        &1, // Capacity 1
+        &String::from_str(&f.env, "Show"),
+        &price,
+        &f.token,
+        &5u32,
+        &future_date(&f.env),
+        &0u32,
     );
 
-    let buyer1 = Address::generate(&env);
-    client.purchase_ticket(&event_id, &buyer1);
+    f.client.purchase_ticket(&event_id, &buyer);
 
-    let buyer2 = Address::generate(&env);
-    client.purchase_ticket(&event_id, &buyer2); // Should panic
+    let token_client = TokenClient::new(&f.env, &f.token);
+    let platform = f.client.get_platform_account();
+    let expected_fee = price / 10; // 10% in bps == 1000
+    assert_eq!(token_client.balance(&merchant_account), price - expected_fee);
+    assert_eq!(token_client.balance(&platform), expected_fee);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #47)")] // EventSoldOut
+fn purchase_ticket_panics_when_sold_out() {
+    let f = setup();
+    let (merchant, _) = register_merchant_with_account(&f.env, &f.client, &f.token);
+
+    let buyer1 = Address::generate(&f.env);
+    let buyer2 = Address::generate(&f.env);
+    fund(&f.env, &f.token, &buyer1, TOKEN_INITIAL_BALANCE);
+    fund(&f.env, &f.token, &buyer2, TOKEN_INITIAL_BALANCE);
+
+    let event_id = f.client.create_event(
+        &merchant,
+        &String::from_str(&f.env, "Tiny"),
+        &100i128,
+        &f.token,
+        &1u32,
+        &future_date(&f.env),
+        &0u32,
+    );
+    f.client.purchase_ticket(&event_id, &buyer1);
+    f.client.purchase_ticket(&event_id, &buyer2);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #46)")] // EventNotFound
+fn purchase_ticket_panics_when_event_missing() {
+    let f = setup();
+    let buyer = Address::generate(&f.env);
+    fund(&f.env, &f.token, &buyer, TOKEN_INITIAL_BALANCE);
+    f.client.purchase_ticket(&999u64, &buyer);
+}
+
+// ── #254 Resale royalty split ────────────────────────────────────────────────
+
+#[test]
+fn resale_splits_royalty_and_proceeds() {
+    let f = setup();
+    let (merchant, merchant_account) =
+        register_merchant_with_account(&f.env, &f.client, &f.token);
+
+    let buyer1 = Address::generate(&f.env);
+    let buyer2 = Address::generate(&f.env);
+    fund(&f.env, &f.token, &buyer1, TOKEN_INITIAL_BALANCE);
+    fund(&f.env, &f.token, &buyer2, TOKEN_INITIAL_BALANCE);
+
+    let primary_price: i128 = 1_000;
+    let event_id = f.client.create_event(
+        &merchant,
+        &String::from_str(&f.env, "Show"),
+        &primary_price,
+        &f.token,
+        &10u32,
+        &future_date(&f.env),
+        &1_000u32, // 10% royalty
+    );
+
+    let ticket_id = f.client.purchase_ticket(&event_id, &buyer1);
+
+    let token_client = TokenClient::new(&f.env, &f.token);
+    let merchant_balance_before_resale = token_client.balance(&merchant_account);
+    let buyer1_balance_before_resale = token_client.balance(&buyer1);
+    let buyer2_balance_before_resale = token_client.balance(&buyer2);
+
+    let resale_price: i128 = 2_000;
+    f.client
+        .resell_ticket(&buyer1, &buyer2, &ticket_id, &resale_price);
+
+    let expected_royalty = resale_price / 10; // 10%
+    let expected_seller_proceeds = resale_price - expected_royalty;
+
+    // Royalty went to the merchant account.
+    assert_eq!(
+        token_client.balance(&merchant_account),
+        merchant_balance_before_resale + expected_royalty
+    );
+    // Original buyer (seller) got the remainder.
+    assert_eq!(
+        token_client.balance(&buyer1),
+        buyer1_balance_before_resale + expected_seller_proceeds
+    );
+    // Reseller paid the full resale price.
+    assert_eq!(
+        token_client.balance(&buyer2),
+        buyer2_balance_before_resale - resale_price
+    );
+
+    // Ownership transferred.
+    let ticket = f.client.get_ticket(&ticket_id);
+    assert_eq!(ticket.owner, buyer2);
+
+    // User-ticket index updated for both parties.
+    assert_eq!(f.client.get_user_tickets(&buyer1).len(), 0);
+    let buyer2_tickets = f.client.get_user_tickets(&buyer2);
+    assert_eq!(buyer2_tickets.len(), 1);
+    assert_eq!(buyer2_tickets.get_unchecked(0), ticket_id);
+}
+
+#[test]
+fn resale_with_zero_royalty_pays_seller_in_full() {
+    let f = setup();
+    let (merchant, _) = register_merchant_with_account(&f.env, &f.client, &f.token);
+
+    let buyer1 = Address::generate(&f.env);
+    let buyer2 = Address::generate(&f.env);
+    fund(&f.env, &f.token, &buyer1, TOKEN_INITIAL_BALANCE);
+    fund(&f.env, &f.token, &buyer2, TOKEN_INITIAL_BALANCE);
+
+    let event_id = f.client.create_event(
+        &merchant,
+        &String::from_str(&f.env, "NoRoyalty"),
+        &500i128,
+        &f.token,
+        &10u32,
+        &future_date(&f.env),
+        &0u32,
+    );
+
+    let ticket_id = f.client.purchase_ticket(&event_id, &buyer1);
+
+    let token_client = TokenClient::new(&f.env, &f.token);
+    let buyer1_before = token_client.balance(&buyer1);
+    let resale_price: i128 = 750;
+    f.client
+        .resell_ticket(&buyer1, &buyer2, &ticket_id, &resale_price);
+    assert_eq!(token_client.balance(&buyer1), buyer1_before + resale_price);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #52)")] // NotTicketOwner
+fn resale_rejects_non_owner_seller() {
+    let f = setup();
+    let (merchant, _) = register_merchant_with_account(&f.env, &f.client, &f.token);
+
+    let buyer1 = Address::generate(&f.env);
+    let imposter = Address::generate(&f.env);
+    let buyer2 = Address::generate(&f.env);
+    fund(&f.env, &f.token, &buyer1, TOKEN_INITIAL_BALANCE);
+    fund(&f.env, &f.token, &buyer2, TOKEN_INITIAL_BALANCE);
+
+    let event_id = f.client.create_event(
+        &merchant,
+        &String::from_str(&f.env, "X"),
+        &100i128,
+        &f.token,
+        &5u32,
+        &future_date(&f.env),
+        &500u32,
+    );
+    let ticket_id = f.client.purchase_ticket(&event_id, &buyer1);
+
+    f.client
+        .resell_ticket(&imposter, &buyer2, &ticket_id, &200i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #54)")] // InvalidResalePrice
+fn resale_rejects_zero_price() {
+    let f = setup();
+    let (merchant, _) = register_merchant_with_account(&f.env, &f.client, &f.token);
+
+    let buyer1 = Address::generate(&f.env);
+    let buyer2 = Address::generate(&f.env);
+    fund(&f.env, &f.token, &buyer1, TOKEN_INITIAL_BALANCE);
+
+    let event_id = f.client.create_event(
+        &merchant,
+        &String::from_str(&f.env, "X"),
+        &100i128,
+        &f.token,
+        &5u32,
+        &future_date(&f.env),
+        &500u32,
+    );
+    let ticket_id = f.client.purchase_ticket(&event_id, &buyer1);
+    f.client.resell_ticket(&buyer1, &buyer2, &ticket_id, &0i128);
+}
+
+#[test]
+#[should_panic(expected = "Error(Contract, #51)")] // TicketNotFound
+fn resale_rejects_unknown_ticket() {
+    let f = setup();
+    let (_merchant, _) = register_merchant_with_account(&f.env, &f.client, &f.token);
+    let a = Address::generate(&f.env);
+    let b = Address::generate(&f.env);
+    f.client.resell_ticket(&a, &b, &999u64, &100i128);
 }

--- a/contracts/shade/src/types.rs
+++ b/contracts/shade/src/types.rs
@@ -40,6 +40,10 @@ pub enum DataKey {
     // --- Event system ---
     Event(u64),
     EventCount,
+    Ticket(u64),
+    TicketCount,
+    EventTickets(u64),
+    UserTickets(Address),
     // --- Global token analytics ---
     TokenAnalytics(Address),
     TokenVolume(Address),
@@ -62,25 +66,6 @@ pub struct Merchant {
     pub date_registered: u64,
     pub account: Address,
     pub webhook: String,
-}
-
-#[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Invoice {
-    pub id: u64,
-    pub description: soroban_sdk::String,
-    pub amount: i128,
-    pub token: Address,
-    pub status: InvoiceStatus,
-    pub merchant_id: u64,
-    pub payer: Option<Address>,
-    pub date_created: u64,
-    pub date_paid: Option<u64>,
-    pub amount_paid: i128,
-    pub amount_refunded: i128,
-    pub expires_at: Option<u64>,
-    pub pricing_mode: InvoicePricingMode,
-    pub fiat_pricing: Option<FiatPricing>,
 }
 
 #[contracttype]
@@ -110,6 +95,25 @@ pub struct FiatPricing {
     pub currency: String,
     pub amount: i128,
     pub decimals: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Invoice {
+    pub id: u64,
+    pub description: soroban_sdk::String,
+    pub amount: i128,
+    pub token: Address,
+    pub status: InvoiceStatus,
+    pub merchant_id: u64,
+    pub payer: Option<Address>,
+    pub date_created: u64,
+    pub date_paid: Option<u64>,
+    pub amount_paid: i128,
+    pub amount_refunded: i128,
+    pub expires_at: Option<u64>,
+    pub pricing_mode: InvoicePricingMode,
+    pub fiat_pricing: Option<FiatPricing>,
 }
 
 #[contracttype]
@@ -285,6 +289,19 @@ pub struct Event {
     pub capacity: u32,
     pub sold: u32,
     pub date: u64,
+    /// Scheduled event date (unix seconds). Must be >= ledger timestamp at creation.
+    pub event_date: u64,
+    /// Royalty paid to the organizer on each resale, in basis points (10_000 = 100%).
+    pub royalty_bps: u32,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Ticket {
+    pub id: u64,
+    pub event_id: u64,
+    pub owner: Address,
+    pub minted_at: u64,
 }
 
 #[contracttype]


### PR DESCRIPTION
## Summary

Implements the Shade contract's event ticketing system end to end: paid event creation, on-chain payment via Shade, NFT-style ticket minting, and royalty-enforced secondary resale.

Closes #246 (Event Creation Logic), #247 (Shade Payment Integration), #248 (Ticket Minting Logic), #254 (Royalty Fee on Resale).

## What landed

- **Event creation (#246)**: extended `Event` with `event_date` and `royalty_bps`. `create_event` validates `ticket_price > 0`, `capacity > 0`, `royalty_bps <= 10_000`, `event_date >= ledger_timestamp`, and that the token is platform-accepted.
- **Payment integration (#247)**: `purchase_ticket` now actually transfers `ticket_price - fee` to the merchant account and the fee to the platform account, then records merchant analytics — using the same primitives as `pay_invoice`. Validations run before any state mutation.
- **Ticket minting (#248)**: introduced `Ticket { id, event_id, owner, minted_at }`. Each purchase mints a unique ticket, persists it under `DataKey::Ticket(id)`, and indexes it per-event (`EventTickets`) and per-user (`UserTickets`).
- **Resale royalty (#254)**: `resell_ticket(seller, buyer, ticket_id, resale_price)` splits the resale price into `royalty = price * royalty_bps / 10_000` to the organizer and the remainder to the seller, then transfers ownership. Royalty math uses `checked_mul` to catch overflow.
- **Errors**: 10 new variants (EventNotFound, EventSoldOut, InvalidCapacity, InvalidEventDate, InvalidRoyaltyBps, TicketNotFound, NotTicketOwner, TicketEventMismatch, InvalidResalePrice — plus reuse of existing payment errors).
- **Events emitted**: `EventCreatedEvent`, `TicketPurchasedEvent`, `TicketResoldEvent`.

## Tests

`contracts/shade/src/tests/test_event_tickets.rs` covers:

- ✅ Create event stores all fields
- ✅ Reject zero price / zero capacity / royalty > 100% / past event date
- ✅ Purchase moves funds and mints a ticket; user index updated; sold counter incremented
- ✅ Platform fee routed correctly when configured
- ✅ Sold-out rejection
- ✅ Missing-event rejection
- ✅ Resale splits royalty to organizer + remainder to seller; ownership and indexes updated
- ✅ Zero-royalty resale pays seller in full
- ✅ Reject non-owner seller / zero resale price / unknown ticket id

## Repo health fixes bundled in (main was red on `cargo check`)

These were already broken on `main` before this PR — folding the minimal fixes in so the lib compiles and CI can run:

- `components/admin.rs`: replaced `std::vec::Vec` (the crate is `#![no_std]`) with an in-place insertion sort on `soroban_sdk::Vec`.
- `shade.rs`: removed four impl methods (`get_daily_volume`, `get_weekly_volume`, `get_merchant_daily_volume`, `get_merchant_weekly_volume`) that were not declared in `ShadeTrait` and delegated to nonexistent `admin_component` functions.
- `interface.rs`: imported `PaymentPayload` (used by `validate_payment_payload` but missing from the use list).
- `types.rs`: moved `FiatPricing` above `Invoice` so the macro expansion for `Option<FiatPricing>` resolves cleanly.

## Test plan

- [x] `cargo check -p shade` clean (was failing on main pre-PR)
- [ ] CI runs `cargo test --workspace --all-features` on Linux
- [ ] CI clippy + fmt