### PR TITLE
feat: group ticket bookings with discounts, subscription contract, plan storage, billing auth

### DIFF
--- a/contracts/shade/src/components/event.rs
+++ b/contracts/shade/src/components/event.rs
@@ -1,7 +1,7 @@
 use crate::components::{core, merchant};
 use crate::errors::ContractError;
 use crate::types::{DataKey, Event, Merchant};
-use soroban_sdk::{panic_with_error, Address, Env, String};
+use soroban_sdk::{panic_with_error, token, Address, Env, String};
 
 pub fn create_event(
     env: &Env,
@@ -73,4 +73,57 @@ pub fn get_event(env: &Env, event_id: &u64) -> Event {
         .persistent()
         .get(&DataKey::Event(*event_id))
         .unwrap()
+}
+
+/// Discount tiers: quantity → basis-point discount off the total price.
+/// 500 bps = 5%, 1000 bps = 10%, 1500 bps = 15%.
+fn group_discount_bps(quantity: u32) -> i128 {
+    if quantity >= 20 {
+        1500
+    } else if quantity >= 10 {
+        1000
+    } else if quantity >= 5 {
+        500
+    } else {
+        0
+    }
+}
+
+/// Purchase multiple tickets for an event in a single call with automatic
+/// group discount applied in Shade tokens.  The buyer pays the discounted
+/// total in one transfer; the merchant receives the net amount.
+pub fn purchase_tickets_bulk(
+    env: &Env,
+    event_id: &u64,
+    buyer: &Address,
+    quantity: u32,
+    shade_token: &Address,
+    merchant_account: &Address,
+) {
+    buyer.require_auth();
+
+    if quantity == 0 {
+        panic_with_error!(env, ContractError::InvalidAmount);
+    }
+
+    let mut event: Event = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Event(*event_id))
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::InvoiceNotFound));
+
+    if event.sold.saturating_add(quantity) > event.capacity {
+        panic_with_error!(env, ContractError::InvalidAmount);
+    }
+
+    let gross = event.ticket_price.saturating_mul(i128::from(quantity));
+    let discount_bps = group_discount_bps(quantity);
+    let discount_amount = gross * discount_bps / 10_000;
+    let net = gross - discount_amount;
+
+    let token_client = token::TokenClient::new(env, shade_token);
+    token_client.transfer(buyer, merchant_account, &net);
+
+    event.sold = event.sold.saturating_add(quantity);
+    env.storage().persistent().set(&DataKey::Event(*event_id), &event);
 }

--- a/contracts/shade/src/interface.rs
+++ b/contracts/shade/src/interface.rs
@@ -179,6 +179,18 @@ pub trait ShadeTrait {
     fn purchase_ticket(env: Env, event_id: u64, buyer: Address);
     fn get_event(env: Env, event_id: u64) -> Event;
 
+    /// Purchase multiple tickets in a single call.
+    /// Applies automatic group discount in Shade tokens:
+    /// 5–9 tickets → 5%, 10–19 → 10%, 20+ → 15%.
+    fn purchase_tickets_bulk(
+        env: Env,
+        event_id: u64,
+        buyer: Address,
+        quantity: u32,
+        shade_token: Address,
+        merchant_account: Address,
+    );
+
     // ── Token analytics ────────────────────────────────────────────────────────
 
     /// Get comprehensive analytics for a specific token

--- a/contracts/shade/src/shade.rs
+++ b/contracts/shade/src/shade.rs
@@ -483,6 +483,25 @@ impl ShadeTrait for Shade {
         crate::components::event::get_event(&env, &event_id)
     }
 
+    fn purchase_tickets_bulk(
+        env: Env,
+        event_id: u64,
+        buyer: Address,
+        quantity: u32,
+        shade_token: Address,
+        merchant_account: Address,
+    ) {
+        pausable_component::assert_not_paused(&env);
+        crate::components::event::purchase_tickets_bulk(
+            &env,
+            &event_id,
+            &buyer,
+            quantity,
+            &shade_token,
+            &merchant_account,
+        );
+    }
+
     fn get_token_analytics(env: Env, token: Address) -> TokenAnalytics {
         admin_component::get_token_analytics(&env, &token)
     }

--- a/contracts/subscription/Cargo.toml
+++ b/contracts/subscription/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "subscription"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/subscription/src/errors.rs
+++ b/contracts/subscription/src/errors.rs
@@ -1,0 +1,19 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum SubscriptionError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    NotAuthorized = 3,
+    InvalidAmount = 4,
+    InvalidInterval = 5,
+    PlanNotFound = 6,
+    PlanNotActive = 7,
+    SubscriptionNotFound = 8,
+    SubscriptionNotActive = 9,
+    ChargeTooEarly = 10,
+    InsufficientAllowance = 11,
+    TokenNotAccepted = 12,
+}

--- a/contracts/subscription/src/lib.rs
+++ b/contracts/subscription/src/lib.rs
@@ -127,6 +127,40 @@ impl SubscriptionContract {
         load_plan(&env, plan_id)
     }
 
+    pub fn get_plan_count(env: Env) -> u64 {
+        get_plan_count(&env)
+    }
+
+    /// Update the billing amount for an existing plan.
+    /// Only the plan's merchant may call this; existing subscriptions are not
+    /// retroactively affected until the next charge cycle.
+    pub fn update_plan_amount(env: Env, merchant: Address, plan_id: u64, new_amount: i128) {
+        merchant.require_auth();
+        if new_amount <= 0 {
+            panic_with_error!(&env, SubscriptionError::InvalidAmount);
+        }
+        let mut plan = load_plan(&env, plan_id);
+        if plan.merchant != merchant {
+            panic_with_error!(&env, SubscriptionError::NotAuthorized);
+        }
+        plan.amount = new_amount;
+        env.storage().persistent().set(&DataKey::Plan(plan_id), &plan);
+    }
+
+    /// Update the billing interval for an existing plan (in seconds).
+    pub fn update_plan_interval(env: Env, merchant: Address, plan_id: u64, new_interval: u64) {
+        merchant.require_auth();
+        if new_interval == 0 {
+            panic_with_error!(&env, SubscriptionError::InvalidInterval);
+        }
+        let mut plan = load_plan(&env, plan_id);
+        if plan.merchant != merchant {
+            panic_with_error!(&env, SubscriptionError::NotAuthorized);
+        }
+        plan.interval = new_interval;
+        env.storage().persistent().set(&DataKey::Plan(plan_id), &plan);
+    }
+
     pub fn deactivate_plan(env: Env, merchant: Address, plan_id: u64) {
         merchant.require_auth();
         let mut plan = load_plan(&env, plan_id);

--- a/contracts/subscription/src/lib.rs
+++ b/contracts/subscription/src/lib.rs
@@ -1,0 +1,236 @@
+#![no_std]
+
+mod errors;
+mod types;
+
+use errors::SubscriptionError;
+use soroban_sdk::{
+    contract, contractimpl, panic_with_error, token, Address, Env, String, Vec,
+};
+use types::{DataKey, Plan, Subscription, SubscriptionStatus};
+
+fn require_admin(env: &Env) -> Address {
+    let admin: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| panic_with_error!(env, SubscriptionError::NotInitialized));
+    admin.require_auth();
+    admin
+}
+
+fn get_plan_count(env: &Env) -> u64 {
+    env.storage().persistent().get(&DataKey::PlanCount).unwrap_or(0)
+}
+
+fn get_subscription_count(env: &Env) -> u64 {
+    env.storage().persistent().get(&DataKey::SubscriptionCount).unwrap_or(0)
+}
+
+fn load_plan(env: &Env, plan_id: u64) -> Plan {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Plan(plan_id))
+        .unwrap_or_else(|| panic_with_error!(env, SubscriptionError::PlanNotFound))
+}
+
+fn load_subscription(env: &Env, sub_id: u64) -> Subscription {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Subscription(sub_id))
+        .unwrap_or_else(|| panic_with_error!(env, SubscriptionError::SubscriptionNotFound))
+}
+
+#[contract]
+pub struct SubscriptionContract;
+
+#[contractimpl]
+impl SubscriptionContract {
+    // ── Admin ─────────────────────────────────────────────────────────────────
+
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic_with_error!(&env, SubscriptionError::AlreadyInitialized);
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn add_accepted_token(env: Env, token: Address) {
+        require_admin(&env);
+        let mut tokens: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AcceptedTokens)
+            .unwrap_or_else(|| Vec::new(&env));
+        if !tokens.contains(&token) {
+            tokens.push_back(token);
+            env.storage().persistent().set(&DataKey::AcceptedTokens, &tokens);
+        }
+    }
+
+    pub fn is_accepted_token(env: Env, token: Address) -> bool {
+        let tokens: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AcceptedTokens)
+            .unwrap_or_else(|| Vec::new(&env));
+        tokens.contains(&token)
+    }
+
+    // ── Plans ─────────────────────────────────────────────────────────────────
+
+    /// Create a recurring billing plan.  Returns the new plan ID.
+    pub fn create_plan(
+        env: Env,
+        merchant: Address,
+        description: String,
+        token: Address,
+        amount: i128,
+        interval: u64,
+    ) -> u64 {
+        merchant.require_auth();
+
+        if amount <= 0 {
+            panic_with_error!(&env, SubscriptionError::InvalidAmount);
+        }
+        if interval == 0 {
+            panic_with_error!(&env, SubscriptionError::InvalidInterval);
+        }
+
+        let accepted: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AcceptedTokens)
+            .unwrap_or_else(|| Vec::new(&env));
+        if !accepted.contains(&token) {
+            panic_with_error!(&env, SubscriptionError::TokenNotAccepted);
+        }
+
+        let plan_id = get_plan_count(&env) + 1;
+        env.storage().persistent().set(&DataKey::PlanCount, &plan_id);
+
+        let plan = Plan {
+            id: plan_id,
+            merchant,
+            description,
+            token,
+            amount,
+            interval,
+            active: true,
+            created_at: env.ledger().timestamp(),
+        };
+        env.storage().persistent().set(&DataKey::Plan(plan_id), &plan);
+        plan_id
+    }
+
+    pub fn get_plan(env: Env, plan_id: u64) -> Plan {
+        load_plan(&env, plan_id)
+    }
+
+    pub fn deactivate_plan(env: Env, merchant: Address, plan_id: u64) {
+        merchant.require_auth();
+        let mut plan = load_plan(&env, plan_id);
+        if plan.merchant != merchant {
+            panic_with_error!(&env, SubscriptionError::NotAuthorized);
+        }
+        plan.active = false;
+        env.storage().persistent().set(&DataKey::Plan(plan_id), &plan);
+    }
+
+    // ── Subscriptions ─────────────────────────────────────────────────────────
+
+    /// Subscribe a customer to a plan.  Returns the new subscription ID.
+    pub fn subscribe(env: Env, customer: Address, plan_id: u64) -> u64 {
+        customer.require_auth();
+
+        let plan = load_plan(&env, plan_id);
+        if !plan.active {
+            panic_with_error!(&env, SubscriptionError::PlanNotActive);
+        }
+
+        let sub_id = get_subscription_count(&env) + 1;
+        env.storage().persistent().set(&DataKey::SubscriptionCount, &sub_id);
+
+        let sub = Subscription {
+            id: sub_id,
+            plan_id,
+            customer,
+            status: SubscriptionStatus::Active,
+            created_at: env.ledger().timestamp(),
+            last_charged: 0,
+        };
+        env.storage().persistent().set(&DataKey::Subscription(sub_id), &sub);
+        sub_id
+    }
+
+    pub fn get_subscription(env: Env, sub_id: u64) -> Subscription {
+        load_subscription(&env, sub_id)
+    }
+
+    pub fn cancel_subscription(env: Env, caller: Address, sub_id: u64) {
+        caller.require_auth();
+        let mut sub = load_subscription(&env, sub_id);
+        if sub.status != SubscriptionStatus::Active {
+            panic_with_error!(&env, SubscriptionError::SubscriptionNotActive);
+        }
+        let plan = load_plan(&env, sub.plan_id);
+        if sub.customer != caller && plan.merchant != caller {
+            panic_with_error!(&env, SubscriptionError::NotAuthorized);
+        }
+        sub.status = SubscriptionStatus::Cancelled;
+        env.storage().persistent().set(&DataKey::Subscription(sub_id), &sub);
+    }
+
+    // ── Billing ───────────────────────────────────────────────────────────────
+
+    /// Authorise the contract as a spender so it can pull recurring charges.
+    /// The customer must call this before the first charge (and top-up as needed).
+    pub fn authorize_billing(
+        env: Env,
+        customer: Address,
+        sub_id: u64,
+        cycles: u32,
+    ) {
+        customer.require_auth();
+        let sub = load_subscription(&env, sub_id);
+        if sub.customer != customer {
+            panic_with_error!(&env, SubscriptionError::NotAuthorized);
+        }
+        if sub.status != SubscriptionStatus::Active {
+            panic_with_error!(&env, SubscriptionError::SubscriptionNotActive);
+        }
+        let plan = load_plan(&env, sub.plan_id);
+        let allowance_amount = plan.amount.saturating_mul(i128::from(cycles));
+
+        let ledger_expiry = env.ledger().sequence() + 17_280 * u32::from(cycles);
+        let token_client = token::TokenClient::new(&env, &plan.token);
+        let spender = env.current_contract_address();
+        token_client.approve(&customer, &spender, &allowance_amount, &ledger_expiry);
+    }
+
+    /// Charge the next billing cycle for a subscription.
+    pub fn charge(env: Env, sub_id: u64) {
+        let mut sub = load_subscription(&env, sub_id);
+        if sub.status != SubscriptionStatus::Active {
+            panic_with_error!(&env, SubscriptionError::SubscriptionNotActive);
+        }
+        let plan = load_plan(&env, sub.plan_id);
+        let now = env.ledger().timestamp();
+        if sub.last_charged > 0 && now < sub.last_charged.saturating_add(plan.interval) {
+            panic_with_error!(&env, SubscriptionError::ChargeTooEarly);
+        }
+
+        let token_client = token::TokenClient::new(&env, &plan.token);
+        let spender = env.current_contract_address();
+
+        let allowance = token_client.allowance(&sub.customer, &spender);
+        if allowance < plan.amount {
+            panic_with_error!(&env, SubscriptionError::InsufficientAllowance);
+        }
+
+        token_client.transfer_from(&spender, &sub.customer, &plan.merchant, &plan.amount);
+
+        sub.last_charged = now;
+        env.storage().persistent().set(&DataKey::Subscription(sub_id), &sub);
+    }
+}

--- a/contracts/subscription/src/lib.rs
+++ b/contracts/subscription/src/lib.rs
@@ -242,6 +242,33 @@ impl SubscriptionContract {
         token_client.approve(&customer, &spender, &allowance_amount, &ledger_expiry);
     }
 
+    /// Return the current token allowance the contract holds from a customer.
+    /// Callers can use this to verify a sufficient allowance exists before
+    /// attempting a charge.
+    pub fn get_billing_allowance(env: Env, customer: Address, sub_id: u64) -> i128 {
+        let sub = load_subscription(&env, sub_id);
+        let plan = load_plan(&env, sub.plan_id);
+        let token_client = token::TokenClient::new(&env, &plan.token);
+        let spender = env.current_contract_address();
+        token_client.allowance(&customer, &spender)
+    }
+
+    /// Revoke the contract's spending allowance for a customer on a given
+    /// subscription.  This effectively prevents future automatic charges
+    /// without cancelling the subscription record.
+    pub fn revoke_billing_authorization(env: Env, customer: Address, sub_id: u64) {
+        customer.require_auth();
+        let sub = load_subscription(&env, sub_id);
+        if sub.customer != customer {
+            panic_with_error!(&env, SubscriptionError::NotAuthorized);
+        }
+        let plan = load_plan(&env, sub.plan_id);
+        let token_client = token::TokenClient::new(&env, &plan.token);
+        let spender = env.current_contract_address();
+        let current_seq = env.ledger().sequence();
+        token_client.approve(&customer, &spender, &0_i128, &current_seq);
+    }
+
     /// Charge the next billing cycle for a subscription.
     pub fn charge(env: Env, sub_id: u64) {
         let mut sub = load_subscription(&env, sub_id);

--- a/contracts/subscription/src/types.rs
+++ b/contracts/subscription/src/types.rs
@@ -1,0 +1,49 @@
+use soroban_sdk::{contracttype, Address, String};
+
+#[contracttype]
+pub enum DataKey {
+    Admin,
+    AcceptedTokens,
+    Plan(u64),
+    PlanCount,
+    Subscription(u64),
+    SubscriptionCount,
+}
+
+/// A billing plan created by a merchant.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Plan {
+    pub id: u64,
+    pub merchant: Address,
+    pub description: String,
+    /// Token used for recurring billing.
+    pub token: Address,
+    /// Amount charged per interval (in token base units).
+    pub amount: i128,
+    /// Billing interval in seconds (e.g. 2_592_000 = 30 days).
+    pub interval: u64,
+    pub active: bool,
+    pub created_at: u64,
+}
+
+/// An active or cancelled subscription held by a customer.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Subscription {
+    pub id: u64,
+    pub plan_id: u64,
+    pub customer: Address,
+    pub status: SubscriptionStatus,
+    pub created_at: u64,
+    /// Timestamp of the last successful charge; 0 means never charged.
+    pub last_charged: u64,
+}
+
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum SubscriptionStatus {
+    Active = 0,
+    Cancelled = 1,
+}


### PR DESCRIPTION
## Summary

- Add `purchase_tickets_bulk` to the event component in the main Shade contract, applying tiered Shade-token group discounts (5–9 qty → 5%, 10–19 → 10%, 20+ → 15%) with a single `token.transfer` to the merchant. Exposed through `ShadeTrait` and the `Shade` impl, guarded by the pausable check (#266)
- Create `contracts/subscription` as a standalone Soroban contract with `initialize`, `add_accepted_token`, `is_accepted_token`, `subscribe`, `get_subscription`, `cancel_subscription`, `charge`, plus full `Plan`/`Subscription` contracttypes, `SubscriptionStatus` enum, `DataKey` enum, and `SubscriptionError` contracterror (#269)
- Add `get_plan_count`, `update_plan_amount`, and `update_plan_interval` to the subscription contract; plans store cost (token base units) and interval (seconds) dynamically and can be updated by the owning merchant at any time (#270)
- Add `authorize_billing` (approve N cycles of allowance with ledger-based expiry), `get_billing_allowance` (inspect current allowance before a charge), and `revoke_billing_authorization` (zero out allowance without cancelling the subscription) to the subscription contract (#272)

## Issues

Closes #266
Closes #269
Closes #270
Closes #272

## Test plan

- [ ] `purchase_tickets_bulk` applies correct discount tiers and transfers net amount in one call
- [ ] Subscription contract initializes, accepts tokens, and creates plans with stored cost and interval
- [ ] `update_plan_amount` / `update_plan_interval` update stored values; only the plan merchant may call them
- [ ] `authorize_billing` sets a token allowance; `get_billing_allowance` returns it; `charge` deducts it; `revoke_billing_authorization` zeroes it