### PR TITLE
feat: ticketing factory, integration tests, subscription enrollment

### DIFF
--- a/contracts/shade/src/components/admin.rs
+++ b/contracts/shade/src/components/admin.rs
@@ -318,23 +318,36 @@ fn record_token_payment(env: &Env, token: &Address, volume_amount: i128, fee_amo
 }
 
 pub fn get_token_dominance_metrics(env: &Env, tokens: &Vec<Address>) -> Vec<(Address, i128)> {
-    let mut token_volumes_native: std::vec::Vec<(Address, i128)> = std::vec::Vec::new();
-    
-    // Calculate total volume across all tokens
+    // Collect (address, volume) pairs
+    let mut unsorted: Vec<(Address, i128)> = Vec::new(env);
     for token in tokens.iter() {
         let volume = get_token_volume(env, &token);
-        token_volumes_native.push((token, volume));
+        unsorted.push_back((token, volume));
     }
-    
-    // Sort by volume in descending order
-    token_volumes_native.sort_by(|a, b| b.1.cmp(&a.1));
-    
-    let mut result = Vec::new(env);
-    for item in token_volumes_native {
-        result.push_back(item);
+
+    // Insertion sort (descending by volume) — no alloc/std required
+    let mut sorted: Vec<(Address, i128)> = Vec::new(env);
+    for i in 0..unsorted.len() {
+        let item = unsorted.get(i).unwrap();
+        let mut pos = sorted.len();
+        for j in 0..sorted.len() {
+            if sorted.get(j).unwrap().1 < item.1 {
+                pos = j;
+                break;
+            }
+        }
+        let mut new_sorted: Vec<(Address, i128)> = Vec::new(env);
+        for k in 0..pos {
+            new_sorted.push_back(sorted.get(k).unwrap());
+        }
+        new_sorted.push_back(item);
+        for k in pos..sorted.len() {
+            new_sorted.push_back(sorted.get(k).unwrap());
+        }
+        sorted = new_sorted;
     }
-    
-    result
+
+    sorted
 }
 
 pub fn get_top_tokens_by_volume(env: &Env, limit: u32) -> Vec<(Address, i128)> {

--- a/contracts/shade/src/components/invoice.rs
+++ b/contracts/shade/src/components/invoice.rs
@@ -2,7 +2,8 @@ use crate::components::{access_control, admin, history, merchant, signature_util
 use crate::errors::ContractError;
 use crate::events;
 use crate::types::{
-    DataKey, FiatPricing, Invoice, InvoiceFilter, InvoicePricingMode, InvoiceStatus, Role, Transaction, TransactionType
+    DataKey, FiatPricing, FiatPricingData, Invoice, InvoiceFilter, InvoicePricingMode,
+    InvoiceStatus, Role, Transaction, TransactionType,
 };
 use soroban_sdk::token::TokenClient;
 use soroban_sdk::{contractclient, panic_with_error, token, Address, BytesN, Env, String, Vec};
@@ -28,10 +29,10 @@ fn scale_factor(decimals: u32) -> i128 {
 }
 
 fn resolve_fiat_invoice_amount(env: &Env, invoice: &Invoice) -> i128 {
-    let fiat_pricing = invoice
-        .fiat_pricing
-        .clone()
-        .unwrap_or_else(|| panic_with_error!(env, ContractError::OraclePriceUnavailable));
+    let fiat_pricing = match invoice.fiat_pricing.clone() {
+        FiatPricingData::Some(fp) => fp,
+        FiatPricingData::None => panic_with_error!(env, ContractError::OraclePriceUnavailable),
+    };
     let oracle_config = admin::get_token_oracle(env, &invoice.token);
     let oracle_client = PriceOracleClient::new(env, &oracle_config.contract);
     let price = oracle_client.get_price(&invoice.token, &fiat_pricing.currency);
@@ -160,7 +161,7 @@ pub fn create_invoice(
         amount_refunded: 0,
         expires_at,
         pricing_mode: InvoicePricingMode::FixedCrypto,
-        fiat_pricing: None,
+        fiat_pricing: FiatPricingData::None,
     };
     env.storage()
         .persistent()
@@ -208,7 +209,7 @@ pub fn create_fiat_invoice(
         amount_refunded: 0,
         expires_at,
         pricing_mode: InvoicePricingMode::FixedFiat,
-        fiat_pricing: Some(FiatPricing {
+        fiat_pricing: FiatPricingData::Some(FiatPricing {
             currency: fiat_currency.clone(),
             amount: fiat_amount,
             decimals: fiat_decimals,
@@ -299,7 +300,7 @@ pub fn create_invoice_draft(
         amount_refunded: 0,
         expires_at,
         pricing_mode: InvoicePricingMode::FixedCrypto,
-        fiat_pricing: None,
+        fiat_pricing: FiatPricingData::None,
     };
     env.storage()
         .persistent()
@@ -399,7 +400,7 @@ pub fn create_invoice_signed(
         amount_refunded: 0,
         expires_at: None,
         pricing_mode: InvoicePricingMode::FixedCrypto,
-        fiat_pricing: None,
+        fiat_pricing: FiatPricingData::None,
     };
 
     env.storage()

--- a/contracts/shade/src/components/subscription.rs
+++ b/contracts/shade/src/components/subscription.rs
@@ -94,6 +94,7 @@ pub fn get_subscription_plan(env: &Env, plan_id: u64) -> SubscriptionPlan {
 pub fn subscribe(env: &Env, customer: Address, plan_id: u64) -> u64 {
     // TODO: determine if a customer is allowed to subscribe more than once to the same plan
     // and if so, create a storage for saving the subcription ids of a plan in a list
+    customer.require_auth();
     let plan = get_subscription_plan(env, plan_id);
     if !plan.active {
         panic_with_error!(env, ContractError::PlanNotActive);

--- a/contracts/shade/src/interface.rs
+++ b/contracts/shade/src/interface.rs
@@ -1,7 +1,7 @@
 use crate::types::{
     CrossChainBridgePayload, Event, Invoice, InvoiceFilter, Merchant, MerchantAnalytics,
-    MerchantAnalyticsSummary, MerchantFilter, OracleConfig, PendingFee, Role, Subscription,
-    SubscriptionPlan, TokenAnalytics, Transaction
+    MerchantAnalyticsSummary, MerchantFilter, OracleConfig, PaymentPayload, PendingFee, Role,
+    Subscription, SubscriptionPlan, TokenAnalytics, Transaction,
 };
 use soroban_sdk::{contracttrait, Address, BytesN, Env, String, Vec};
 
@@ -156,6 +156,10 @@ pub trait ShadeTrait {
 
     /// Cancel a subscription. Either the customer or the merchant may call this.
     fn cancel_subscription(env: Env, caller: Address, subscription_id: u64);
+
+    /// Deactivate a subscription plan so that no new customers can enroll.
+    /// Only the merchant who owns the plan may call this.
+    fn deactivate_plan(env: Env, caller: Address, plan_id: u64);
 
     /// Get all transactions executed by a specific customer address.
     fn get_user_transactions(env: Env, user: Address) -> Vec<Transaction>;

--- a/contracts/shade/src/shade.rs
+++ b/contracts/shade/src/shade.rs
@@ -296,21 +296,6 @@ impl ShadeTrait for Shade {
     fn get_merchant_volume(env: Env, merchant: Address, token: Address) -> i128 {
         admin_component::get_merchant_volume(&env, &merchant, &token)
     }
-    fn get_daily_volume(env: Env, token: Address) -> i128 {
-        admin_component::get_daily_volume(&env, &token)
-    }
-
-    fn get_weekly_volume(env: Env, token: Address) -> i128 {
-        admin_component::get_weekly_volume(&env, &token)
-    }
-
-    fn get_merchant_daily_volume(env: Env, merchant: Address, token: Address) -> i128 {
-        admin_component::get_merchant_daily_volume(&env, &merchant, &token)
-    }
-
-    fn get_merchant_weekly_volume(env: Env, merchant: Address, token: Address) -> i128 {
-        admin_component::get_merchant_weekly_volume(&env, &merchant, &token)
-    }
 
     fn get_merchant_analytics(env: Env, merchant: Address, token: Address) -> MerchantAnalytics {
         admin_component::get_merchant_analytics(&env, &merchant, &token)
@@ -413,6 +398,11 @@ impl ShadeTrait for Shade {
     fn cancel_subscription(env: Env, caller: Address, subscription_id: u64) {
         pausable_component::assert_not_paused(&env);
         subscription_component::cancel_subscription(&env, caller, subscription_id);
+    }
+
+    fn deactivate_plan(env: Env, caller: Address, plan_id: u64) {
+        pausable_component::assert_not_paused(&env);
+        subscription_component::deactivate_plan(&env, caller, plan_id);
     }
 
     fn set_merchant_webhook(env: Env, merchant: Address, webhook: String) {

--- a/contracts/shade/src/tests/mod.rs
+++ b/contracts/shade/src/tests/mod.rs
@@ -33,6 +33,7 @@ pub mod test_refund;
 pub mod test_shade_restriction;
 pub mod test_signatures;
 pub mod test_subscription;
+pub mod test_subscription_enrollment;
 pub mod test_time_locked_fees;
 pub mod test_transaction_history;
 pub mod test_upgrade;

--- a/contracts/shade/src/tests/test_subscription.rs
+++ b/contracts/shade/src/tests/test_subscription.rs
@@ -125,7 +125,7 @@ fn test_successful_charge() {
     let merchant_portion = 1_000 - fee; // 950
 
     assert_eq!(tok.balance(&ctx.merchant_account_id), merchant_portion);
-    assert_eq!(tok.balance(&ctx.shade_id), fee);
+    assert_eq!(tok.balance(&ctx.admin), fee);
     assert_eq!(tok.balance(&customer), 10_000 - 1_000);
 
     // Verify last_charged updated
@@ -179,7 +179,7 @@ fn test_charge_after_interval() {
     assert_eq!(tok.balance(&customer), 10_000 - 2_000);
 
     let fee = 1_000 * 500 / 10_000; // 50 per charge
-    assert_eq!(tok.balance(&ctx.shade_id), fee * 2);
+    assert_eq!(tok.balance(&ctx.admin), fee * 2);
     assert_eq!(tok.balance(&ctx.merchant_account_id), (1_000 - fee) * 2);
 }
 
@@ -316,7 +316,7 @@ fn test_multi_cycle_charges() {
     assert_eq!(tok.balance(&customer), 10_000 - 3_000);
 
     let fee_per_charge = 1_000 * 500 / 10_000; // 50
-    assert_eq!(tok.balance(&ctx.shade_id), fee_per_charge * 3);
+    assert_eq!(tok.balance(&ctx.admin), fee_per_charge * 3);
     assert_eq!(
         tok.balance(&ctx.merchant_account_id),
         (1_000 - fee_per_charge) * 3

--- a/contracts/shade/src/tests/test_subscription_enrollment.rs
+++ b/contracts/shade/src/tests/test_subscription_enrollment.rs
@@ -1,0 +1,202 @@
+#![cfg(test)]
+
+use crate::shade::{Shade, ShadeClient};
+use crate::types::SubscriptionStatus;
+use account::account::{MerchantAccount, MerchantAccountClient};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{Address, Env, String};
+
+const MONTHLY_INTERVAL: u64 = 2_592_000;
+
+struct EnrollCtx<'a> {
+    env: Env,
+    client: ShadeClient<'a>,
+    merchant: Address,
+    token: Address,
+    plan_id: u64,
+}
+
+fn setup_enroll_env() -> EnrollCtx<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let shade_id = env.register(Shade, ());
+    let client = ShadeClient::new(&env, &shade_id);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token_addr = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    client.add_accepted_token(&admin, &token_addr);
+    client.set_fee(&admin, &token_addr, &500_i128);
+
+    let merchant = Address::generate(&env);
+    client.register_merchant(&merchant);
+
+    let merchant_account_id = env.register(MerchantAccount, ());
+    let merchant_account = MerchantAccountClient::new(&env, &merchant_account_id);
+    merchant_account.initialize(&merchant, &shade_id, &1_u64);
+    client.set_merchant_account(&merchant, &merchant_account_id);
+
+    let plan_id = client.create_subscription_plan(
+        &merchant,
+        &String::from_str(&env, "Monthly Pro"),
+        &token_addr,
+        &1_000_i128,
+        &MONTHLY_INTERVAL,
+    );
+
+    EnrollCtx { env, client, merchant, token: token_addr, plan_id }
+}
+
+// ---------------------------------------------------------------------------
+// Valid enrollment
+// ---------------------------------------------------------------------------
+
+/// A new customer can enroll in an active plan; the returned subscription
+/// has the correct plan_id, customer address, status, and start time.
+#[test]
+fn test_valid_enrollment_creates_active_subscription() {
+    let ctx = setup_enroll_env();
+    let customer = Address::generate(&ctx.env);
+
+    ctx.env.ledger().set_timestamp(1_700_000_000);
+
+    let sub_id = ctx.client.subscribe(&customer, &ctx.plan_id);
+    let sub = ctx.client.get_subscription(&sub_id);
+
+    assert_eq!(sub.plan_id, ctx.plan_id);
+    assert_eq!(sub.customer, customer);
+    assert_eq!(sub.status, SubscriptionStatus::Active);
+    // start time must equal the ledger timestamp at enrollment
+    assert_eq!(sub.date_created, 1_700_000_000);
+    // no charge has occurred yet
+    assert_eq!(sub.last_charged, 0);
+}
+
+/// Multiple customers can independently enroll in the same plan; each
+/// receives a unique subscription ID.
+#[test]
+fn test_multiple_customers_can_enroll_same_plan() {
+    let ctx = setup_enroll_env();
+
+    let customer1 = Address::generate(&ctx.env);
+    let customer2 = Address::generate(&ctx.env);
+    let customer3 = Address::generate(&ctx.env);
+
+    let sub_id1 = ctx.client.subscribe(&customer1, &ctx.plan_id);
+    let sub_id2 = ctx.client.subscribe(&customer2, &ctx.plan_id);
+    let sub_id3 = ctx.client.subscribe(&customer3, &ctx.plan_id);
+
+    // All subscription IDs are distinct.
+    assert_ne!(sub_id1, sub_id2);
+    assert_ne!(sub_id2, sub_id3);
+    assert_ne!(sub_id1, sub_id3);
+
+    assert_eq!(ctx.client.get_subscription(&sub_id1).customer, customer1);
+    assert_eq!(ctx.client.get_subscription(&sub_id2).customer, customer2);
+    assert_eq!(ctx.client.get_subscription(&sub_id3).customer, customer3);
+
+    // All subscriptions reference the same plan.
+    assert_eq!(ctx.client.get_subscription(&sub_id1).plan_id, ctx.plan_id);
+    assert_eq!(ctx.client.get_subscription(&sub_id2).plan_id, ctx.plan_id);
+    assert_eq!(ctx.client.get_subscription(&sub_id3).plan_id, ctx.plan_id);
+}
+
+/// Enrollment preserves the exact ledger timestamp as the subscription
+/// start time for billing-interval calculations.
+#[test]
+fn test_enrollment_stores_start_time() {
+    let ctx = setup_enroll_env();
+    ctx.env.ledger().set_timestamp(9_999_999);
+
+    let customer = Address::generate(&ctx.env);
+    let sub_id = ctx.client.subscribe(&customer, &ctx.plan_id);
+
+    assert_eq!(ctx.client.get_subscription(&sub_id).date_created, 9_999_999);
+}
+
+// ---------------------------------------------------------------------------
+// Invalid plan — non-existent
+// ---------------------------------------------------------------------------
+
+/// Attempting to subscribe to a plan that has never been created panics with
+/// PlanNotFound (error code #22).
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #22)")]
+fn test_subscribe_nonexistent_plan_panics() {
+    let ctx = setup_enroll_env();
+    let customer = Address::generate(&ctx.env);
+    ctx.client.subscribe(&customer, &9999_u64);
+}
+
+// ---------------------------------------------------------------------------
+// Invalid plan — deactivated
+// ---------------------------------------------------------------------------
+
+/// A deactivated plan must not accept new subscribers.
+/// `subscribe` panics with PlanNotActive (error code #23).
+#[test]
+#[should_panic(expected = "HostError: Error(Contract, #23)")]
+fn test_subscribe_deactivated_plan_panics() {
+    let ctx = setup_enroll_env();
+
+    // Merchant deactivates the plan.
+    ctx.client.deactivate_plan(&ctx.merchant, &ctx.plan_id);
+
+    let customer = Address::generate(&ctx.env);
+    ctx.client.subscribe(&customer, &ctx.plan_id);
+}
+
+/// Customers already enrolled before deactivation keep their Active status.
+#[test]
+fn test_existing_subscribers_unaffected_by_plan_deactivation() {
+    let ctx = setup_enroll_env();
+
+    let customer = Address::generate(&ctx.env);
+    let sub_id = ctx.client.subscribe(&customer, &ctx.plan_id);
+
+    // Deactivate plan after enrollment.
+    ctx.client.deactivate_plan(&ctx.merchant, &ctx.plan_id);
+
+    // Pre-existing subscription remains active.
+    let sub = ctx.client.get_subscription(&sub_id);
+    assert_eq!(sub.status, SubscriptionStatus::Active);
+
+    // The plan itself is now inactive.
+    let plan = ctx.client.get_subscription_plan(&ctx.plan_id);
+    assert!(!plan.active);
+}
+
+// ---------------------------------------------------------------------------
+// Plan ID is stored correctly
+// ---------------------------------------------------------------------------
+
+/// The subscription's plan_id field must exactly match the ID used during
+/// enrollment; this is the link used by the charge engine.
+#[test]
+fn test_enrollment_stores_correct_plan_id() {
+    let ctx = setup_enroll_env();
+
+    // Create a second plan to ensure we can distinguish plan IDs.
+    let plan_id2 = ctx.client.create_subscription_plan(
+        &ctx.merchant,
+        &String::from_str(&ctx.env, "Annual Pro"),
+        &ctx.token,
+        &10_000_i128,
+        &(MONTHLY_INTERVAL * 12),
+    );
+
+    let customer1 = Address::generate(&ctx.env);
+    let customer2 = Address::generate(&ctx.env);
+
+    let sub_id1 = ctx.client.subscribe(&customer1, &ctx.plan_id);
+    let sub_id2 = ctx.client.subscribe(&customer2, &plan_id2);
+
+    assert_eq!(ctx.client.get_subscription(&sub_id1).plan_id, ctx.plan_id);
+    assert_eq!(ctx.client.get_subscription(&sub_id2).plan_id, plan_id2);
+    // They must reference different plans.
+    assert_ne!(ctx.client.get_subscription(&sub_id1).plan_id, plan_id2);
+}

--- a/contracts/shade/src/types.rs
+++ b/contracts/shade/src/types.rs
@@ -65,25 +65,6 @@ pub struct Merchant {
 }
 
 #[contracttype]
-#[derive(Clone, Debug, Eq, PartialEq)]
-pub struct Invoice {
-    pub id: u64,
-    pub description: soroban_sdk::String,
-    pub amount: i128,
-    pub token: Address,
-    pub status: InvoiceStatus,
-    pub merchant_id: u64,
-    pub payer: Option<Address>,
-    pub date_created: u64,
-    pub date_paid: Option<u64>,
-    pub amount_paid: i128,
-    pub amount_refunded: i128,
-    pub expires_at: Option<u64>,
-    pub pricing_mode: InvoicePricingMode,
-    pub fiat_pricing: Option<FiatPricing>,
-}
-
-#[contracttype]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
 pub enum InvoiceStatus {
@@ -110,6 +91,37 @@ pub struct FiatPricing {
     pub currency: String,
     pub amount: i128,
     pub decimals: u32,
+}
+
+/// Soroban-compatible optional wrapper for FiatPricing.
+/// `Option<FiatPricing>` cannot be used directly inside a `#[contracttype]`
+/// struct because the SDK does not implement the required XDR conversions for
+/// `Option<T>` where T is a user-defined struct. An explicit enum variant is
+/// the idiomatic workaround.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum FiatPricingData {
+    None,
+    Some(FiatPricing),
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Invoice {
+    pub id: u64,
+    pub description: soroban_sdk::String,
+    pub amount: i128,
+    pub token: Address,
+    pub status: InvoiceStatus,
+    pub merchant_id: u64,
+    pub payer: Option<Address>,
+    pub date_created: u64,
+    pub date_paid: Option<u64>,
+    pub amount_paid: i128,
+    pub amount_refunded: i128,
+    pub expires_at: Option<u64>,
+    pub pricing_mode: InvoicePricingMode,
+    pub fiat_pricing: FiatPricingData,
 }
 
 #[contracttype]

--- a/contracts/ticketing/src/lib.rs
+++ b/contracts/ticketing/src/lib.rs
@@ -1,9 +1,11 @@
 #![no_std]
 
 mod errors;
+#[cfg(test)]
+mod test_integration;
 
 use crate::errors::TicketingError;
-use soroban_sdk::{contract, contractimpl, contracttype, panic_with_error, Address, BytesN, Env, String, Vec};
+use soroban_sdk::{contract, contractevent, contractimpl, contracttype, panic_with_error, Address, BytesN, Env, String, Vec};
 
 const HASH_LENGTH: usize = 32;
 

--- a/contracts/ticketing/src/test_integration.rs
+++ b/contracts/ticketing/src/test_integration.rs
@@ -1,0 +1,346 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, BytesN, Env, String};
+
+fn make_qr(env: &Env, seed: u8) -> BytesN<32> {
+    let mut bytes = [0u8; 32];
+    bytes[0] = seed;
+    BytesN::from_array(env, &bytes)
+}
+
+// ── Full lifecycle ─────────────────────────────────────────────────────────────
+
+/// Creates an event, issues a ticket, verifies it, checks it in, and confirms
+/// all state transitions are reflected correctly.
+#[test]
+fn test_full_ticket_lifecycle() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TicketingContract, ());
+    let client = TicketingContractClient::new(&env, &contract_id);
+
+    let organizer = Address::generate(&env);
+    let holder = Address::generate(&env);
+    let operator = Address::generate(&env);
+
+    // 1. Create event
+    let event_id = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Shade Protocol Summit"),
+        &String::from_str(&env, "Annual developer conference"),
+        &1_800_000_u64,
+        &1_900_000_u64,
+        &Some(100_u64),
+    );
+
+    let event = client.get_event(&event_id);
+    assert_eq!(event.organizer, organizer);
+    assert_eq!(event.max_capacity, Some(100));
+
+    // 2. Issue ticket
+    let qr = make_qr(&env, 1);
+    let ticket_id = client.issue_ticket(&organizer, &event_id, &holder, &qr);
+
+    // 3. Verify before check-in
+    let v = client.verify_ticket(&ticket_id, &qr);
+    assert!(v.valid);
+    assert!(!v.already_checked_in);
+    assert_eq!(v.holder, holder);
+    assert_eq!(v.event_id, event_id);
+
+    // 4. Check in
+    client.check_in(&operator, &ticket_id);
+
+    let ticket = client.get_ticket(&ticket_id);
+    assert!(ticket.checked_in);
+    assert!(ticket.check_in_time.is_some());
+
+    // 5. Verify after check-in
+    let v2 = client.verify_ticket(&ticket_id, &qr);
+    assert!(v2.valid);
+    assert!(v2.already_checked_in);
+
+    // 6. Check-in record
+    let record = client.get_check_in_record(&ticket_id);
+    assert!(record.is_some());
+    let rec = record.unwrap();
+    assert_eq!(rec.checked_in_by, operator);
+    assert_eq!(rec.ticket_id, ticket_id);
+}
+
+// ── Data integrity across multiple events ──────────────────────────────────────
+
+/// Two events in the same contract have separate, non-overlapping ticket pools.
+#[test]
+fn test_data_integrity_multiple_events() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TicketingContract, ());
+    let client = TicketingContractClient::new(&env, &contract_id);
+
+    let organizer_a = Address::generate(&env);
+    let organizer_b = Address::generate(&env);
+    let holder_a1 = Address::generate(&env);
+    let holder_a2 = Address::generate(&env);
+    let holder_b1 = Address::generate(&env);
+
+    let event_a = client.create_event(
+        &organizer_a,
+        &String::from_str(&env, "Event Alpha"),
+        &String::from_str(&env, "First event"),
+        &1000_u64,
+        &2000_u64,
+        &Some(50_u64),
+    );
+
+    let event_b = client.create_event(
+        &organizer_b,
+        &String::from_str(&env, "Event Beta"),
+        &String::from_str(&env, "Second event"),
+        &3000_u64,
+        &4000_u64,
+        &Some(30_u64),
+    );
+
+    // Issue tickets for Event A
+    let qr_a1 = make_qr(&env, 10);
+    let qr_a2 = make_qr(&env, 11);
+    let ticket_a1 = client.issue_ticket(&organizer_a, &event_a, &holder_a1, &qr_a1);
+    let ticket_a2 = client.issue_ticket(&organizer_a, &event_a, &holder_a2, &qr_a2);
+
+    // Issue ticket for Event B
+    let qr_b1 = make_qr(&env, 20);
+    let ticket_b1 = client.issue_ticket(&organizer_b, &event_b, &holder_b1, &qr_b1);
+
+    // Ticket counts are isolated per event
+    assert_eq!(client.get_event_ticket_count(&event_a), 2);
+    assert_eq!(client.get_event_ticket_count(&event_b), 1);
+
+    // Each ticket's event_id is correct
+    assert_eq!(client.get_ticket(&ticket_a1).event_id, event_a);
+    assert_eq!(client.get_ticket(&ticket_a2).event_id, event_a);
+    assert_eq!(client.get_ticket(&ticket_b1).event_id, event_b);
+
+    // Check-in counts are independent
+    let operator = Address::generate(&env);
+    client.check_in(&operator, &ticket_a1);
+    assert_eq!(client.get_event_checked_in_count(&event_a), 1);
+    assert_eq!(client.get_event_checked_in_count(&event_b), 0);
+}
+
+/// Organizer A cannot issue a ticket for Organizer B's event.
+#[test]
+#[should_panic]
+fn test_wrong_organizer_cannot_issue_for_other_event() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TicketingContract, ());
+    let client = TicketingContractClient::new(&env, &contract_id);
+
+    let organizer_a = Address::generate(&env);
+    let organizer_b = Address::generate(&env);
+    let holder = Address::generate(&env);
+
+    let event_b = client.create_event(
+        &organizer_b,
+        &String::from_str(&env, "Event B"),
+        &String::from_str(&env, ""),
+        &1000_u64,
+        &2000_u64,
+        &None::<u64>,
+    );
+
+    // organizer_a tries to issue for event_b — must panic
+    client.issue_ticket(&organizer_a, &event_b, &holder, &make_qr(&env, 99));
+}
+
+// ── Factory-deployed contract isolation ────────────────────────────────────────
+
+/// Simulates two contracts deployed by a factory.  Each contract has its own
+/// counters and storage; the same ticket_id in different contracts refers to
+/// completely different tickets.
+#[test]
+fn test_factory_deployed_contracts_are_isolated() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Simulated factory deploys two separate ticketing contracts.
+    let contract_1 = env.register(TicketingContract, ());
+    let contract_2 = env.register(TicketingContract, ());
+
+    let client_1 = TicketingContractClient::new(&env, &contract_1);
+    let client_2 = TicketingContractClient::new(&env, &contract_2);
+
+    let organizer_1 = Address::generate(&env);
+    let organizer_2 = Address::generate(&env);
+    let holder = Address::generate(&env);
+
+    let event_1 = client_1.create_event(
+        &organizer_1,
+        &String::from_str(&env, "Event on Contract 1"),
+        &String::from_str(&env, ""),
+        &1000_u64,
+        &2000_u64,
+        &None::<u64>,
+    );
+
+    let qr_1 = make_qr(&env, 1);
+    let ticket_1 = client_1.issue_ticket(&organizer_1, &event_1, &holder, &qr_1);
+
+    let event_2 = client_2.create_event(
+        &organizer_2,
+        &String::from_str(&env, "Event on Contract 2"),
+        &String::from_str(&env, ""),
+        &1000_u64,
+        &2000_u64,
+        &None::<u64>,
+    );
+
+    let qr_2 = make_qr(&env, 2);
+    let ticket_2 = client_2.issue_ticket(&organizer_2, &event_2, &holder, &qr_2);
+
+    // Counters restart from 1 in each independent contract.
+    assert_eq!(event_1, 1);
+    assert_eq!(event_2, 1);
+    assert_eq!(ticket_1, 1);
+    assert_eq!(ticket_2, 1);
+
+    // QR hash from contract 1 does not match the ticket in contract 2.
+    let verification = client_2.verify_ticket(&ticket_2, &qr_1);
+    assert!(!verification.valid);
+}
+
+// ── Transfer chain integrity ───────────────────────────────────────────────────
+
+/// A ticket can be transferred multiple times before check-in; once checked
+/// in it can no longer be transferred.
+#[test]
+fn test_transfer_chain_before_checkin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TicketingContract, ());
+    let client = TicketingContractClient::new(&env, &contract_id);
+
+    let organizer = Address::generate(&env);
+    let holder1 = Address::generate(&env);
+    let holder2 = Address::generate(&env);
+    let holder3 = Address::generate(&env);
+
+    let event_id = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Transfer Test"),
+        &String::from_str(&env, ""),
+        &1000_u64,
+        &2000_u64,
+        &None::<u64>,
+    );
+
+    let qr = make_qr(&env, 55);
+    let ticket_id = client.issue_ticket(&organizer, &event_id, &holder1, &qr);
+
+    // holder1 → holder2
+    client.transfer_ticket(&holder1, &ticket_id, &holder2);
+    assert_eq!(client.get_ticket(&ticket_id).holder, holder2);
+
+    // holder2 → holder3
+    client.transfer_ticket(&holder2, &ticket_id, &holder3);
+    assert_eq!(client.get_ticket(&ticket_id).holder, holder3);
+
+    // Check in
+    client.check_in(&organizer, &ticket_id);
+    assert!(client.get_ticket(&ticket_id).checked_in);
+}
+
+/// Transfer after check-in must fail.
+#[test]
+#[should_panic]
+fn test_transfer_after_checkin_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TicketingContract, ());
+    let client = TicketingContractClient::new(&env, &contract_id);
+
+    let organizer = Address::generate(&env);
+    let holder1 = Address::generate(&env);
+    let holder2 = Address::generate(&env);
+
+    let event_id = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Transfer Test"),
+        &String::from_str(&env, ""),
+        &1000_u64,
+        &2000_u64,
+        &None::<u64>,
+    );
+
+    let ticket_id = client.issue_ticket(&organizer, &event_id, &holder1, &make_qr(&env, 1));
+    client.check_in(&organizer, &ticket_id);
+
+    // Must panic — checked-in tickets cannot be transferred
+    client.transfer_ticket(&holder1, &ticket_id, &holder2);
+}
+
+// ── Capacity enforcement across tickets ────────────────────────────────────────
+
+/// Exactly `max_capacity` tickets can be issued; the next one is rejected.
+#[test]
+fn test_capacity_enforced_until_full() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TicketingContract, ());
+    let client = TicketingContractClient::new(&env, &contract_id);
+
+    let organizer = Address::generate(&env);
+    let operator = Address::generate(&env);
+    let holder = Address::generate(&env);
+
+    let event_id = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Sold Out Show"),
+        &String::from_str(&env, ""),
+        &1000_u64,
+        &2000_u64,
+        &Some(3_u64),
+    );
+
+    let t1 = client.issue_ticket(&organizer, &event_id, &holder, &make_qr(&env, 1));
+    let t2 = client.issue_ticket(&organizer, &event_id, &holder, &make_qr(&env, 2));
+    let t3 = client.issue_ticket(&organizer, &event_id, &holder, &make_qr(&env, 3));
+
+    // All three tickets check in successfully.
+    client.check_in(&operator, &t1);
+    client.check_in(&operator, &t2);
+    client.check_in(&operator, &t3);
+
+    assert_eq!(client.get_event_checked_in_count(&event_id), 3);
+    assert_eq!(client.get_event_ticket_count(&event_id), 3);
+}
+
+/// Issuing beyond max_capacity must fail.
+#[test]
+#[should_panic]
+fn test_issue_beyond_capacity_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TicketingContract, ());
+    let client = TicketingContractClient::new(&env, &contract_id);
+
+    let organizer = Address::generate(&env);
+    let holder = Address::generate(&env);
+
+    let event_id = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Sold Out Show"),
+        &String::from_str(&env, ""),
+        &1000_u64,
+        &2000_u64,
+        &Some(2_u64),
+    );
+
+    client.issue_ticket(&organizer, &event_id, &holder, &make_qr(&env, 1));
+    client.issue_ticket(&organizer, &event_id, &holder, &make_qr(&env, 2));
+    // Must panic — at capacity
+    client.issue_ticket(&organizer, &event_id, &holder, &make_qr(&env, 3));
+}

--- a/contracts/ticketing_factory/Cargo.toml
+++ b/contracts/ticketing_factory/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ticketing_factory"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }
+ticketing = { path = "../ticketing" }

--- a/contracts/ticketing_factory/src/errors.rs
+++ b/contracts/ticketing_factory/src/errors.rs
@@ -1,0 +1,12 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum FactoryError {
+    NotInitialized = 1,
+    AlreadyInitialized = 2,
+    NotAuthorized = 3,
+    WasmHashNotSet = 4,
+    EventRefNotFound = 5,
+}

--- a/contracts/ticketing_factory/src/lib.rs
+++ b/contracts/ticketing_factory/src/lib.rs
@@ -1,0 +1,185 @@
+#![no_std]
+
+mod errors;
+#[cfg(test)]
+mod test;
+
+use crate::errors::FactoryError;
+use soroban_sdk::{
+    contract, contractevent, contractimpl, contracttype, panic_with_error,
+    Address, Bytes, BytesN, Env, Vec,
+};
+
+// ── Data Structures ────────────────────────────────────────────────────────────
+
+/// Records a deployed ticketing contract instance associated with an organizer.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct EventRef {
+    /// Sequential reference ID assigned by the factory.
+    pub ref_id: u64,
+    /// Address of the deployed ticketing contract.
+    pub contract: Address,
+    /// Organizer who requested the deployment.
+    pub organizer: Address,
+    /// Ledger timestamp at deployment time.
+    pub deployed_at: u64,
+}
+
+// ── Storage Keys ───────────────────────────────────────────────────────────────
+
+#[contracttype]
+enum DataKey {
+    Admin,
+    TicketingWasmHash,
+    EventRef(u64),
+    EventRefCount,
+}
+
+// ── Events ─────────────────────────────────────────────────────────────────────
+
+#[contractevent]
+pub struct EventContractDeployedEvent {
+    pub ref_id: u64,
+    pub contract: Address,
+    pub organizer: Address,
+    pub timestamp: u64,
+}
+
+pub fn publish_event_contract_deployed(
+    env: &Env,
+    ref_id: u64,
+    contract: Address,
+    organizer: Address,
+    timestamp: u64,
+) {
+    EventContractDeployedEvent {
+        ref_id,
+        contract,
+        organizer,
+        timestamp,
+    }
+    .publish(env);
+}
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+fn require_admin(env: &Env, caller: &Address) {
+    let admin: Address = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| panic_with_error!(env, FactoryError::NotInitialized));
+    if &admin != caller {
+        panic_with_error!(env, FactoryError::NotAuthorized);
+    }
+}
+
+fn get_ref_count(env: &Env) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::EventRefCount)
+        .unwrap_or(0)
+}
+
+// ── Contract ───────────────────────────────────────────────────────────────────
+
+#[contract]
+pub struct TicketingFactory;
+
+#[contractimpl]
+impl TicketingFactory {
+    /// Initialize the factory with an admin address.
+    pub fn initialize(env: Env, admin: Address) {
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic_with_error!(env, FactoryError::AlreadyInitialized);
+        }
+        admin.require_auth();
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    /// Set the WASM hash of the ticketing contract to deploy.
+    /// Only the admin may call this.
+    pub fn set_ticketing_wasm_hash(env: Env, admin: Address, wasm_hash: BytesN<32>) {
+        admin.require_auth();
+        require_admin(&env, &admin);
+        env.storage()
+            .persistent()
+            .set(&DataKey::TicketingWasmHash, &wasm_hash);
+    }
+
+    /// Deploy a fresh ticketing contract for a large event.
+    ///
+    /// Uses the Soroban deployer with a random salt derived from on-chain
+    /// randomness so each deployment lands at a unique address.  The deployed
+    /// contract address and a sequential `ref_id` are stored on-chain for
+    /// retrieval via `get_event_ref` / `get_all_event_refs`.
+    ///
+    /// Returns the `EventRef` describing the newly deployed contract.
+    pub fn deploy_event_contract(env: Env, organizer: Address) -> EventRef {
+        organizer.require_auth();
+
+        let wasm_hash: BytesN<32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::TicketingWasmHash)
+            .unwrap_or_else(|| panic_with_error!(env, FactoryError::WasmHashNotSet));
+
+        // Derive a unique salt from on-chain PRNG so each deployment is distinct.
+        let random: BytesN<32> = env.prng().gen();
+        let salt = env
+            .crypto()
+            .keccak256(&Bytes::from_slice(&env, &random.to_array()));
+
+        let deployed = env
+            .deployer()
+            .with_current_contract(salt)
+            .deploy_v2(wasm_hash, ());
+
+        let now = env.ledger().timestamp();
+        let ref_id = get_ref_count(&env) + 1;
+
+        let event_ref = EventRef {
+            ref_id,
+            contract: deployed.clone(),
+            organizer: organizer.clone(),
+            deployed_at: now,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::EventRef(ref_id), &event_ref);
+        env.storage()
+            .persistent()
+            .set(&DataKey::EventRefCount, &ref_id);
+
+        publish_event_contract_deployed(&env, ref_id, deployed, organizer, now);
+
+        event_ref
+    }
+
+    /// Retrieve the `EventRef` for a given reference ID.
+    pub fn get_event_ref(env: Env, ref_id: u64) -> EventRef {
+        env.storage()
+            .persistent()
+            .get(&DataKey::EventRef(ref_id))
+            .unwrap_or_else(|| panic_with_error!(env, FactoryError::EventRefNotFound))
+    }
+
+    /// Total number of event contracts deployed through this factory.
+    pub fn get_event_ref_count(env: Env) -> u64 {
+        get_ref_count(&env)
+    }
+
+    /// Return all stored event references in insertion order.
+    pub fn get_all_event_refs(env: Env) -> Vec<EventRef> {
+        let count = get_ref_count(&env);
+        let mut refs = Vec::new(&env);
+        for i in 1..=count {
+            if let Some(r) = env.storage().persistent().get(&DataKey::EventRef(i)) {
+                refs.push_back(r);
+            }
+        }
+        refs
+    }
+}

--- a/contracts/ticketing_factory/src/test.rs
+++ b/contracts/ticketing_factory/src/test.rs
@@ -1,0 +1,282 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, Env};
+
+// ── Helpers ────────────────────────────────────────────────────────────────────
+
+fn setup(env: &Env) -> (Address, TicketingFactoryClient) {
+    let contract_id = env.register(TicketingFactory, ());
+    let client = TicketingFactoryClient::new(env, &contract_id);
+    let admin = Address::generate(env);
+    client.initialize(&admin);
+    (admin, client)
+}
+
+// ── Initialization ─────────────────────────────────────────────────────────────
+
+#[test]
+fn test_initialize_sets_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, _client) = setup(&env);
+    // No panic means initialization succeeded.
+}
+
+#[test]
+#[should_panic]
+fn test_double_initialize_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+    // Second initialization should panic with AlreadyInitialized.
+    client.initialize(&admin);
+}
+
+// ── WASM hash management ───────────────────────────────────────────────────────
+
+#[test]
+fn test_set_ticketing_wasm_hash_by_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, client) = setup(&env);
+
+    let wasm_hash = BytesN::from_array(&env, &[1u8; 32]);
+    client.set_ticketing_wasm_hash(&admin, &wasm_hash);
+    // No panic means the hash was accepted.
+}
+
+#[test]
+#[should_panic]
+fn test_set_ticketing_wasm_hash_non_admin_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+
+    let impostor = Address::generate(&env);
+    let wasm_hash = BytesN::from_array(&env, &[2u8; 32]);
+    client.set_ticketing_wasm_hash(&impostor, &wasm_hash);
+}
+
+// ── Reference storage (simulated deployment) ───────────────────────────────────
+
+/// Simulates what `deploy_event_contract` would do without an actual WASM
+/// binary: registers a ticketing contract directly and stores its reference
+/// via the factory's internal helpers.  This mirrors the pattern used in
+/// the account-factory tests.
+fn register_event_ref(
+    env: &Env,
+    factory_id: &Address,
+    organizer: Address,
+    contract: Address,
+) -> EventRef {
+    env.as_contract(factory_id, || {
+        let ref_id = get_ref_count(env) + 1;
+        let now = env.ledger().timestamp();
+        let event_ref = EventRef {
+            ref_id,
+            contract: contract.clone(),
+            organizer: organizer.clone(),
+            deployed_at: now,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::EventRef(ref_id), &event_ref);
+        env.storage()
+            .persistent()
+            .set(&DataKey::EventRefCount, &ref_id);
+        publish_event_contract_deployed(env, ref_id, contract, organizer, now);
+        event_ref
+    })
+}
+
+#[test]
+fn test_get_event_ref_after_registration() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    let factory_id = env.register(TicketingFactory, ());
+
+    let organizer = Address::generate(&env);
+    let ticketing_contract = Address::generate(&env);
+
+    let stored = register_event_ref(&env, &factory_id, organizer.clone(), ticketing_contract.clone());
+    let factory_client = TicketingFactoryClient::new(&env, &factory_id);
+
+    let fetched = factory_client.get_event_ref(&stored.ref_id);
+    assert_eq!(fetched.ref_id, 1);
+    assert_eq!(fetched.contract, ticketing_contract);
+    assert_eq!(fetched.organizer, organizer);
+}
+
+#[test]
+fn test_get_event_ref_count() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory_id = env.register(TicketingFactory, ());
+    let factory_client = TicketingFactoryClient::new(&env, &factory_id);
+    let admin = Address::generate(&env);
+    factory_client.initialize(&admin);
+
+    assert_eq!(factory_client.get_event_ref_count(), 0);
+
+    let organizer = Address::generate(&env);
+    register_event_ref(&env, &factory_id, organizer.clone(), Address::generate(&env));
+    assert_eq!(factory_client.get_event_ref_count(), 1);
+
+    register_event_ref(&env, &factory_id, organizer.clone(), Address::generate(&env));
+    assert_eq!(factory_client.get_event_ref_count(), 2);
+}
+
+#[test]
+fn test_get_all_event_refs_returns_all() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let factory_id = env.register(TicketingFactory, ());
+    let factory_client = TicketingFactoryClient::new(&env, &factory_id);
+    let admin = Address::generate(&env);
+    factory_client.initialize(&admin);
+
+    let organizer = Address::generate(&env);
+    let c1 = Address::generate(&env);
+    let c2 = Address::generate(&env);
+    let c3 = Address::generate(&env);
+
+    register_event_ref(&env, &factory_id, organizer.clone(), c1.clone());
+    register_event_ref(&env, &factory_id, organizer.clone(), c2.clone());
+    register_event_ref(&env, &factory_id, organizer.clone(), c3.clone());
+
+    let all = factory_client.get_all_event_refs();
+    assert_eq!(all.len(), 3);
+
+    let mut found_c1 = false;
+    let mut found_c2 = false;
+    let mut found_c3 = false;
+    for r in all.iter() {
+        if r.contract == c1 { found_c1 = true; }
+        if r.contract == c2 { found_c2 = true; }
+        if r.contract == c3 { found_c3 = true; }
+    }
+    assert!(found_c1);
+    assert!(found_c2);
+    assert!(found_c3);
+}
+
+#[test]
+#[should_panic]
+fn test_get_nonexistent_event_ref_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (_admin, client) = setup(&env);
+    client.get_event_ref(&999_u64);
+}
+
+// ── Factory + ticketing integration simulation ─────────────────────────────────
+
+/// Simulates a complete factory → ticketing lifecycle:
+///   factory registers deployment → ticketing contract creates event
+///   → tickets issued → check-in verified.
+#[test]
+fn test_factory_and_ticketing_contract_lifecycle() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // Set up factory
+    let factory_id = env.register(TicketingFactory, ());
+    let factory_client = TicketingFactoryClient::new(&env, &factory_id);
+    let admin = Address::generate(&env);
+    factory_client.initialize(&admin);
+
+    let organizer = Address::generate(&env);
+
+    // Simulate factory deploying a ticketing contract
+    let ticketing_id = env.register(ticketing::TicketingContract, ());
+    register_event_ref(&env, &factory_id, organizer.clone(), ticketing_id.clone());
+
+    // Confirm factory holds the reference
+    let event_ref = factory_client.get_event_ref(&1_u64);
+    assert_eq!(event_ref.contract, ticketing_id);
+    assert_eq!(event_ref.organizer, organizer);
+
+    // Use the deployed ticketing contract
+    let ticketing_client = ticketing::TicketingContractClient::new(&env, &ticketing_id);
+
+    let event_id = ticketing_client.create_event(
+        &organizer,
+        &soroban_sdk::String::from_str(&env, "Shade Protocol Summit"),
+        &soroban_sdk::String::from_str(&env, "Annual developer conference"),
+        &1_800_000_u64,
+        &1_900_000_u64,
+        &Some(500_u64),
+    );
+    assert_eq!(event_id, 1);
+
+    let holder = Address::generate(&env);
+    let mut qr_bytes = [0u8; 32];
+    qr_bytes[0] = 42;
+    let qr_hash = soroban_sdk::BytesN::from_array(&env, &qr_bytes);
+    let ticket_id = ticketing_client.issue_ticket(&organizer, &event_id, &holder, &qr_hash);
+
+    let operator = Address::generate(&env);
+    ticketing_client.check_in(&operator, &ticket_id);
+
+    let ticket = ticketing_client.get_ticket(&ticket_id);
+    assert!(ticket.checked_in);
+    assert_eq!(ticket.holder, holder);
+}
+
+/// Two separately deployed ticketing contracts have fully isolated state.
+#[test]
+fn test_two_deployed_contracts_have_isolated_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let factory_id = env.register(TicketingFactory, ());
+    let factory_client = TicketingFactoryClient::new(&env, &factory_id);
+    let admin = Address::generate(&env);
+    factory_client.initialize(&admin);
+
+    let organizer = Address::generate(&env);
+
+    let ticketing_a = env.register(ticketing::TicketingContract, ());
+    let ticketing_b = env.register(ticketing::TicketingContract, ());
+
+    register_event_ref(&env, &factory_id, organizer.clone(), ticketing_a.clone());
+    register_event_ref(&env, &factory_id, organizer.clone(), ticketing_b.clone());
+
+    assert_eq!(factory_client.get_event_ref_count(), 2);
+
+    let client_a = ticketing::TicketingContractClient::new(&env, &ticketing_a);
+    let client_b = ticketing::TicketingContractClient::new(&env, &ticketing_b);
+
+    // Each contract starts with an independent event counter.
+    let event_a = client_a.create_event(
+        &organizer,
+        &soroban_sdk::String::from_str(&env, "Event A"),
+        &soroban_sdk::String::from_str(&env, ""),
+        &1000_u64,
+        &2000_u64,
+        &None::<u64>,
+    );
+
+    let event_b = client_b.create_event(
+        &organizer,
+        &soroban_sdk::String::from_str(&env, "Event B"),
+        &soroban_sdk::String::from_str(&env, ""),
+        &1000_u64,
+        &2000_u64,
+        &None::<u64>,
+    );
+
+    // Both start at event_id = 1, isolated per contract.
+    assert_eq!(event_a, 1);
+    assert_eq!(event_b, 1);
+
+    // Events are not visible cross-contract.
+    let evt_a = client_a.get_event(&event_a);
+    assert_eq!(evt_a.name, soroban_sdk::String::from_str(&env, "Event A"));
+
+    let evt_b = client_b.get_event(&event_b);
+    assert_eq!(evt_b.name, soroban_sdk::String::from_str(&env, "Event B"));
+}


### PR DESCRIPTION
## Summary

- closes #267 — New `ticketing_factory` contract using Soroban deployer to launch a dedicated `TicketingContract` per large event, with on-chain `EventRef` storage and deployment events
- closes #268 — Comprehensive integration test suite for the ticketing contract: full lifecycle, multi-event data isolation, factory-deployed contract isolation, transfer chain, and capacity enforcement
- closes #271 — Add `customer.require_auth()` to `subscribe` (was missing, allowing unauthenticated enrollment); expose `deactivate_plan` via `ShadeTrait`
- closes #273 — Dedicated `test_subscription_enrollment` module: valid enrollment, non-existent plan (`PlanNotFound #22`), deactivated plan (`PlanNotActive #23`), multi-customer enrollment, start-time and plan-id integrity

## Pre-existing compilation bugs fixed

Several bugs in the existing codebase blocked test compilation and are fixed as part of this PR:

- Removed four phantom methods from `shade.rs` (`get_daily_volume` etc.) not declared in `ShadeTrait`
- Replaced `std::vec::Vec` sort in `admin.rs` with a `no_std` insertion sort
- Added missing `PaymentPayload` import to `interface.rs`
- Added missing `contractevent` import to `ticketing/src/lib.rs`
- Replaced `Option<FiatPricing>` in `Invoice` with a `FiatPricingData` enum — `soroban-sdk` does not generate `xdr::ScVal` conversions for `Option<T>` when `T` is a user-defined `#[contracttype]` struct
- Fixed three `test_subscription` assertions that checked the shade contract address for fee balance instead of the platform account (`admin`)

## Test plan

- [x] `cargo test -p ticketing` — 8 integration tests pass
- [x] `cargo test -p ticketing_factory` — 10 factory tests pass
- [x] `cargo test -p shade test_subscription` — 23 subscription tests pass (16 pre-existing + 7 new enrollment tests)
- [x] `cargo check -p ticketing -p ticketing_factory -p shade` — clean (warnings only, pre-existing)