### PR TITLE
ticketing,subscription: tiers, royalties, grace period, prorated refunds

### DIFF
--- a/contracts/subscription/src/errors.rs
+++ b/contracts/subscription/src/errors.rs
@@ -16,4 +16,7 @@ pub enum SubscriptionError {
     ChargeTooEarly = 10,
     InsufficientAllowance = 11,
     TokenNotAccepted = 12,
+    SubscriptionTerminated = 13,
+    GraceNotExpired = 14,
+    NothingToRefund = 15,
 }

--- a/contracts/subscription/src/lib.rs
+++ b/contracts/subscription/src/lib.rs
@@ -1,13 +1,15 @@
 #![no_std]
 
 mod errors;
+#[cfg(test)]
+mod test_grace;
+#[cfg(test)]
+mod test_refund;
 mod types;
 
 use errors::SubscriptionError;
-use soroban_sdk::{
-    contract, contractimpl, panic_with_error, token, Address, Env, String, Vec,
-};
-use types::{DataKey, Plan, Subscription, SubscriptionStatus};
+use soroban_sdk::{contract, contractimpl, panic_with_error, token, Address, Env, String, Vec};
+use types::{ChargeOutcome, DataKey, Plan, Subscription, SubscriptionStatus};
 
 fn require_admin(env: &Env) -> Address {
     let admin: Address = env
@@ -20,11 +22,17 @@ fn require_admin(env: &Env) -> Address {
 }
 
 fn get_plan_count(env: &Env) -> u64 {
-    env.storage().persistent().get(&DataKey::PlanCount).unwrap_or(0)
+    env.storage()
+        .persistent()
+        .get(&DataKey::PlanCount)
+        .unwrap_or(0)
 }
 
 fn get_subscription_count(env: &Env) -> u64 {
-    env.storage().persistent().get(&DataKey::SubscriptionCount).unwrap_or(0)
+    env.storage()
+        .persistent()
+        .get(&DataKey::SubscriptionCount)
+        .unwrap_or(0)
 }
 
 fn load_plan(env: &Env, plan_id: u64) -> Plan {
@@ -64,7 +72,9 @@ impl SubscriptionContract {
             .unwrap_or_else(|| Vec::new(&env));
         if !tokens.contains(&token) {
             tokens.push_back(token);
-            env.storage().persistent().set(&DataKey::AcceptedTokens, &tokens);
+            env.storage()
+                .persistent()
+                .set(&DataKey::AcceptedTokens, &tokens);
         }
     }
 
@@ -107,7 +117,9 @@ impl SubscriptionContract {
         }
 
         let plan_id = get_plan_count(&env) + 1;
-        env.storage().persistent().set(&DataKey::PlanCount, &plan_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::PlanCount, &plan_id);
 
         let plan = Plan {
             id: plan_id,
@@ -118,9 +130,28 @@ impl SubscriptionContract {
             interval,
             active: true,
             created_at: env.ledger().timestamp(),
+            grace_period: 0,
         };
-        env.storage().persistent().set(&DataKey::Plan(plan_id), &plan);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Plan(plan_id), &plan);
         plan_id
+    }
+
+    /// Set the grace period (in seconds) for a plan. When a charge fails
+    /// for insufficient allowance, the subscription enters `PastDue` for
+    /// this many seconds before being terminated. Only the plan merchant
+    /// may call this.
+    pub fn set_plan_grace_period(env: Env, merchant: Address, plan_id: u64, grace_period: u64) {
+        merchant.require_auth();
+        let mut plan = load_plan(&env, plan_id);
+        if plan.merchant != merchant {
+            panic_with_error!(&env, SubscriptionError::NotAuthorized);
+        }
+        plan.grace_period = grace_period;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Plan(plan_id), &plan);
     }
 
     pub fn get_plan(env: Env, plan_id: u64) -> Plan {
@@ -144,7 +175,9 @@ impl SubscriptionContract {
             panic_with_error!(&env, SubscriptionError::NotAuthorized);
         }
         plan.amount = new_amount;
-        env.storage().persistent().set(&DataKey::Plan(plan_id), &plan);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Plan(plan_id), &plan);
     }
 
     /// Update the billing interval for an existing plan (in seconds).
@@ -158,7 +191,9 @@ impl SubscriptionContract {
             panic_with_error!(&env, SubscriptionError::NotAuthorized);
         }
         plan.interval = new_interval;
-        env.storage().persistent().set(&DataKey::Plan(plan_id), &plan);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Plan(plan_id), &plan);
     }
 
     pub fn deactivate_plan(env: Env, merchant: Address, plan_id: u64) {
@@ -168,7 +203,9 @@ impl SubscriptionContract {
             panic_with_error!(&env, SubscriptionError::NotAuthorized);
         }
         plan.active = false;
-        env.storage().persistent().set(&DataKey::Plan(plan_id), &plan);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Plan(plan_id), &plan);
     }
 
     // ── Subscriptions ─────────────────────────────────────────────────────────
@@ -183,7 +220,9 @@ impl SubscriptionContract {
         }
 
         let sub_id = get_subscription_count(&env) + 1;
-        env.storage().persistent().set(&DataKey::SubscriptionCount, &sub_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::SubscriptionCount, &sub_id);
 
         let sub = Subscription {
             id: sub_id,
@@ -192,8 +231,11 @@ impl SubscriptionContract {
             status: SubscriptionStatus::Active,
             created_at: env.ledger().timestamp(),
             last_charged: 0,
+            past_due_since: 0,
         };
-        env.storage().persistent().set(&DataKey::Subscription(sub_id), &sub);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(sub_id), &sub);
         sub_id
     }
 
@@ -212,19 +254,16 @@ impl SubscriptionContract {
             panic_with_error!(&env, SubscriptionError::NotAuthorized);
         }
         sub.status = SubscriptionStatus::Cancelled;
-        env.storage().persistent().set(&DataKey::Subscription(sub_id), &sub);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(sub_id), &sub);
     }
 
     // ── Billing ───────────────────────────────────────────────────────────────
 
     /// Authorise the contract as a spender so it can pull recurring charges.
     /// The customer must call this before the first charge (and top-up as needed).
-    pub fn authorize_billing(
-        env: Env,
-        customer: Address,
-        sub_id: u64,
-        cycles: u32,
-    ) {
+    pub fn authorize_billing(env: Env, customer: Address, sub_id: u64, cycles: u32) {
         customer.require_auth();
         let sub = load_subscription(&env, sub_id);
         if sub.customer != customer {
@@ -292,6 +331,202 @@ impl SubscriptionContract {
         token_client.transfer_from(&spender, &sub.customer, &plan.merchant, &plan.amount);
 
         sub.last_charged = now;
-        env.storage().persistent().set(&DataKey::Subscription(sub_id), &sub);
+        sub.past_due_since = 0;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(sub_id), &sub);
     }
+
+    /// Forgiving variant of [`charge`]. Drives the subscription's billing
+    /// state machine — charging, transitioning to `PastDue` on missed
+    /// payment, recovering when allowance returns, or terminating when the
+    /// grace window expires. Returns a [`ChargeOutcome`] describing what
+    /// happened so an off-chain billing bot can react without re-reading
+    /// state.
+    ///
+    /// Unlike `charge`, this never panics on insufficient allowance — that
+    /// failure mode is what the grace-period mechanism is for.
+    pub fn process_charge(env: Env, sub_id: u64) -> ChargeOutcome {
+        let mut sub = load_subscription(&env, sub_id);
+        let plan = load_plan(&env, sub.plan_id);
+        let now = env.ledger().timestamp();
+
+        match sub.status {
+            SubscriptionStatus::Active => {
+                if sub.last_charged > 0 && now < sub.last_charged.saturating_add(plan.interval) {
+                    return ChargeOutcome::NotDueYet;
+                }
+                if try_pull_charge(&env, &sub, &plan) {
+                    sub.last_charged = now;
+                    sub.past_due_since = 0;
+                    env.storage()
+                        .persistent()
+                        .set(&DataKey::Subscription(sub_id), &sub);
+                    ChargeOutcome::Charged
+                } else if plan.grace_period == 0 {
+                    sub.status = SubscriptionStatus::Terminated;
+                    env.storage()
+                        .persistent()
+                        .set(&DataKey::Subscription(sub_id), &sub);
+                    ChargeOutcome::Terminated
+                } else {
+                    sub.status = SubscriptionStatus::PastDue;
+                    sub.past_due_since = now;
+                    env.storage()
+                        .persistent()
+                        .set(&DataKey::Subscription(sub_id), &sub);
+                    ChargeOutcome::EnteredGrace
+                }
+            }
+            SubscriptionStatus::PastDue => {
+                if try_pull_charge(&env, &sub, &plan) {
+                    sub.status = SubscriptionStatus::Active;
+                    sub.last_charged = now;
+                    sub.past_due_since = 0;
+                    env.storage()
+                        .persistent()
+                        .set(&DataKey::Subscription(sub_id), &sub);
+                    ChargeOutcome::Recovered
+                } else if now > sub.past_due_since.saturating_add(plan.grace_period) {
+                    sub.status = SubscriptionStatus::Terminated;
+                    env.storage()
+                        .persistent()
+                        .set(&DataKey::Subscription(sub_id), &sub);
+                    ChargeOutcome::Terminated
+                } else {
+                    ChargeOutcome::EnteredGrace
+                }
+            }
+            SubscriptionStatus::Cancelled | SubscriptionStatus::Terminated => {
+                panic_with_error!(&env, SubscriptionError::SubscriptionNotActive)
+            }
+        }
+    }
+
+    /// Manually terminate a `PastDue` subscription whose grace period has
+    /// fully elapsed. Idempotent for already-terminated subscriptions.
+    /// Anyone may call this — there's no value in restricting it.
+    pub fn enforce_grace(env: Env, sub_id: u64) {
+        let mut sub = load_subscription(&env, sub_id);
+        if sub.status == SubscriptionStatus::Terminated {
+            return;
+        }
+        if sub.status != SubscriptionStatus::PastDue {
+            panic_with_error!(&env, SubscriptionError::SubscriptionNotActive);
+        }
+        let plan = load_plan(&env, sub.plan_id);
+        let now = env.ledger().timestamp();
+        if now <= sub.past_due_since.saturating_add(plan.grace_period) {
+            panic_with_error!(&env, SubscriptionError::GraceNotExpired);
+        }
+        sub.status = SubscriptionStatus::Terminated;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(sub_id), &sub);
+    }
+
+    /// Cancel a subscription and refund the unused portion of the current
+    /// billing cycle to the customer. The merchant must have approved the
+    /// contract to spend at least `refund_amount` from their balance —
+    /// without that allowance the inner `transfer_from` panics and nothing
+    /// is changed.
+    ///
+    /// Refund math: `refund = amount * remaining_seconds / interval`,
+    /// where `remaining_seconds = (last_charged + interval) - now` clamped
+    /// to `[0, interval]`. If the subscription was never charged or the
+    /// cycle has fully elapsed, no refund is issued and the call panics
+    /// with `NothingToRefund`.
+    ///
+    /// Either the customer or the merchant may initiate; both must
+    /// authorize so the merchant cannot drain themselves and the customer
+    /// cannot pull funds without merchant consent.
+    pub fn cancel_with_prorated_refund(env: Env, caller: Address, sub_id: u64) {
+        caller.require_auth();
+        let mut sub = load_subscription(&env, sub_id);
+        if sub.status != SubscriptionStatus::Active && sub.status != SubscriptionStatus::PastDue {
+            panic_with_error!(&env, SubscriptionError::SubscriptionNotActive);
+        }
+        let plan = load_plan(&env, sub.plan_id);
+        let is_customer = sub.customer == caller;
+        let is_merchant = plan.merchant == caller;
+        if !is_customer && !is_merchant {
+            panic_with_error!(&env, SubscriptionError::NotAuthorized);
+        }
+        // Whichever party did not initiate must still authorize so refunds
+        // require mutual consent.
+        if is_customer {
+            plan.merchant.require_auth();
+        } else {
+            sub.customer.require_auth();
+        }
+
+        let refund_amount = prorated_refund(&sub, &plan, env.ledger().timestamp());
+        if refund_amount <= 0 {
+            panic_with_error!(&env, SubscriptionError::NothingToRefund);
+        }
+
+        // Pull the refund from the merchant's balance into the customer's.
+        // The merchant's earlier `approve(contract, ...)` is what makes this
+        // possible — without it the transfer fails and the subscription is
+        // left untouched.
+        let token_client = token::TokenClient::new(&env, &plan.token);
+        let spender = env.current_contract_address();
+        token_client.transfer_from(&spender, &plan.merchant, &sub.customer, &refund_amount);
+
+        sub.status = SubscriptionStatus::Cancelled;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(sub_id), &sub);
+    }
+
+    /// Read-only helper: how much would be refunded if the subscription
+    /// were cancelled right now. Returns 0 when nothing would be refunded.
+    /// Useful for off-chain previews before asking the merchant to approve.
+    pub fn quote_prorated_refund(env: Env, sub_id: u64) -> i128 {
+        let sub = load_subscription(&env, sub_id);
+        let plan = load_plan(&env, sub.plan_id);
+        prorated_refund(&sub, &plan, env.ledger().timestamp())
+    }
+}
+
+/// Attempts a single token pull from customer to merchant for the plan's
+/// amount. Returns `false` if the allowance is insufficient — callers
+/// translate that into a state transition (PastDue / Terminated).
+fn try_pull_charge(env: &Env, sub: &Subscription, plan: &Plan) -> bool {
+    let token_client = token::TokenClient::new(env, &plan.token);
+    let spender = env.current_contract_address();
+    let allowance = token_client.allowance(&sub.customer, &spender);
+    if allowance < plan.amount {
+        return false;
+    }
+    token_client.transfer_from(&spender, &sub.customer, &plan.merchant, &plan.amount);
+    true
+}
+
+/// Compute the prorated refund owed to the customer at `now` for the
+/// remaining unused time in the current billing cycle.
+///
+/// Returns 0 when:
+/// - `last_charged == 0` (never charged — no funds to refund)
+/// - `now >= last_charged + interval` (cycle fully consumed)
+fn prorated_refund(sub: &Subscription, plan: &Plan, now: u64) -> i128 {
+    if sub.last_charged == 0 {
+        return 0;
+    }
+    let cycle_end = sub.last_charged.saturating_add(plan.interval);
+    if now >= cycle_end {
+        return 0;
+    }
+    let remaining = cycle_end - now;
+    let interval = plan.interval as i128;
+    if interval == 0 {
+        return 0;
+    }
+    // amount * remaining / interval; checked_mul guards against overflow on
+    // pathological amounts before we floor-divide.
+    let scaled = match plan.amount.checked_mul(remaining as i128) {
+        Some(v) => v,
+        None => return 0,
+    };
+    scaled / interval
 }

--- a/contracts/subscription/src/test_grace.rs
+++ b/contracts/subscription/src/test_grace.rs
@@ -1,0 +1,286 @@
+use super::*;
+use crate::types::ChargeOutcome;
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::token::{StellarAssetClient, TokenClient};
+use soroban_sdk::{Address, Env, String};
+
+const MONTHLY: u64 = 2_592_000; // 30 days
+const PLAN_AMOUNT: i128 = 1_000;
+
+struct Fixture<'a> {
+    env: Env,
+    contract: Address,
+    client: SubscriptionContractClient<'a>,
+    merchant: Address,
+    customer: Address,
+    token: Address,
+    plan_id: u64,
+    sub_id: u64,
+}
+
+fn fund(env: &Env, token: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+fn approve(env: &Env, token: &Address, owner: &Address, spender: &Address, amount: i128) {
+    let expiry = env.ledger().sequence() + 1_000_000;
+    TokenClient::new(env, token).approve(owner, spender, &amount, &expiry);
+}
+
+fn balance(env: &Env, token: &Address, who: &Address) -> i128 {
+    TokenClient::new(env, token).balance(who)
+}
+
+fn setup_with_grace(grace_period: u64) -> Fixture<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    // The "never charged" sentinel is `last_charged == 0`, so all tests must
+    // run from a non-zero timestamp to avoid collisions when a charge lands.
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+    let contract = env.register(SubscriptionContract, ());
+    let client = SubscriptionContractClient::new(&env, &contract);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    client.add_accepted_token(&token);
+
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+
+    let plan_id = client.create_plan(
+        &merchant,
+        &String::from_str(&env, "Pro Plan"),
+        &token,
+        &PLAN_AMOUNT,
+        &MONTHLY,
+    );
+    if grace_period > 0 {
+        client.set_plan_grace_period(&merchant, &plan_id, &grace_period);
+    }
+
+    let sub_id = client.subscribe(&customer, &plan_id);
+
+    Fixture {
+        env,
+        contract,
+        client,
+        merchant,
+        customer,
+        token,
+        plan_id,
+        sub_id,
+    }
+}
+
+fn advance_time(env: &Env, seconds: u64) {
+    env.ledger().with_mut(|l| {
+        l.timestamp += seconds;
+    });
+}
+
+// ── Grace-period configuration ─────────────────────────────────────────────────
+
+#[test]
+fn test_default_plan_grace_period_is_zero() {
+    let f = setup_with_grace(0);
+    let plan = f.client.get_plan(&f.plan_id);
+    assert_eq!(plan.grace_period, 0);
+}
+
+#[test]
+fn test_set_plan_grace_period_updates_value() {
+    let f = setup_with_grace(0);
+    f.client
+        .set_plan_grace_period(&f.merchant, &f.plan_id, &86_400);
+    assert_eq!(f.client.get_plan(&f.plan_id).grace_period, 86_400);
+}
+
+#[test]
+#[should_panic]
+fn test_non_merchant_cannot_set_grace_period() {
+    let f = setup_with_grace(0);
+    let imposter = Address::generate(&f.env);
+    f.client
+        .set_plan_grace_period(&imposter, &f.plan_id, &86_400);
+}
+
+// ── Process charge outcomes ────────────────────────────────────────────────────
+
+#[test]
+fn test_first_charge_with_sufficient_allowance_returns_charged() {
+    let f = setup_with_grace(86_400);
+    fund(&f.env, &f.token, &f.customer, 5_000);
+    approve(&f.env, &f.token, &f.customer, &f.contract, 5_000);
+
+    let outcome = f.client.process_charge(&f.sub_id);
+    assert_eq!(outcome, ChargeOutcome::Charged);
+    assert_eq!(balance(&f.env, &f.token, &f.merchant), PLAN_AMOUNT);
+}
+
+#[test]
+fn test_charge_before_interval_returns_not_due_yet() {
+    let f = setup_with_grace(86_400);
+    fund(&f.env, &f.token, &f.customer, 5_000);
+    approve(&f.env, &f.token, &f.customer, &f.contract, 5_000);
+
+    f.client.process_charge(&f.sub_id);
+    // Don't advance — the next call is before the interval has elapsed.
+    let outcome = f.client.process_charge(&f.sub_id);
+    assert_eq!(outcome, ChargeOutcome::NotDueYet);
+}
+
+#[test]
+fn test_failed_charge_with_zero_grace_terminates_immediately() {
+    let f = setup_with_grace(0); // No grace.
+                                 // No allowance → charge cannot succeed.
+
+    let outcome = f.client.process_charge(&f.sub_id);
+    assert_eq!(outcome, ChargeOutcome::Terminated);
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).status,
+        SubscriptionStatus::Terminated
+    );
+}
+
+#[test]
+fn test_failed_charge_with_grace_enters_past_due() {
+    let f = setup_with_grace(86_400);
+    let outcome = f.client.process_charge(&f.sub_id);
+    assert_eq!(outcome, ChargeOutcome::EnteredGrace);
+
+    let sub = f.client.get_subscription(&f.sub_id);
+    assert_eq!(sub.status, SubscriptionStatus::PastDue);
+    assert_eq!(sub.past_due_since, f.env.ledger().timestamp());
+}
+
+#[test]
+fn test_past_due_recovery_when_allowance_restored() {
+    let f = setup_with_grace(86_400);
+    // Step 1: charge fails → PastDue.
+    f.client.process_charge(&f.sub_id);
+
+    // Step 2: customer tops up & re-approves within the grace window.
+    advance_time(&f.env, 3_600); // 1 hour later, still inside 24h grace.
+    fund(&f.env, &f.token, &f.customer, 5_000);
+    approve(&f.env, &f.token, &f.customer, &f.contract, 5_000);
+
+    let outcome = f.client.process_charge(&f.sub_id);
+    assert_eq!(outcome, ChargeOutcome::Recovered);
+
+    let sub = f.client.get_subscription(&f.sub_id);
+    assert_eq!(sub.status, SubscriptionStatus::Active);
+    assert_eq!(sub.past_due_since, 0);
+    assert_eq!(balance(&f.env, &f.token, &f.merchant), PLAN_AMOUNT);
+}
+
+#[test]
+fn test_past_due_terminates_after_grace_expires() {
+    let f = setup_with_grace(86_400);
+    f.client.process_charge(&f.sub_id); // → PastDue
+
+    // Advance past the grace window without recovery.
+    advance_time(&f.env, 86_401);
+
+    let outcome = f.client.process_charge(&f.sub_id);
+    assert_eq!(outcome, ChargeOutcome::Terminated);
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).status,
+        SubscriptionStatus::Terminated
+    );
+}
+
+#[test]
+fn test_past_due_within_grace_keeps_state_unchanged_when_still_short() {
+    let f = setup_with_grace(86_400);
+    f.client.process_charge(&f.sub_id); // → PastDue
+    let entered_at = f.client.get_subscription(&f.sub_id).past_due_since;
+
+    advance_time(&f.env, 3_600);
+    let outcome = f.client.process_charge(&f.sub_id);
+    assert_eq!(outcome, ChargeOutcome::EnteredGrace);
+
+    // past_due_since is preserved across re-checks within the window.
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).past_due_since,
+        entered_at
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_process_charge_panics_on_terminated() {
+    let f = setup_with_grace(0);
+    f.client.process_charge(&f.sub_id); // → Terminated
+                                        // Calling again must panic — terminated is final.
+    f.client.process_charge(&f.sub_id);
+}
+
+#[test]
+#[should_panic]
+fn test_process_charge_panics_on_cancelled() {
+    let f = setup_with_grace(86_400);
+    f.client.cancel_subscription(&f.customer, &f.sub_id);
+    f.client.process_charge(&f.sub_id);
+}
+
+// ── enforce_grace ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_enforce_grace_terminates_after_window() {
+    let f = setup_with_grace(86_400);
+    f.client.process_charge(&f.sub_id); // → PastDue
+    advance_time(&f.env, 86_401);
+
+    f.client.enforce_grace(&f.sub_id);
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).status,
+        SubscriptionStatus::Terminated
+    );
+}
+
+#[test]
+fn test_enforce_grace_is_idempotent_on_already_terminated() {
+    let f = setup_with_grace(86_400);
+    f.client.process_charge(&f.sub_id);
+    advance_time(&f.env, 86_401);
+    f.client.enforce_grace(&f.sub_id);
+    // Second call is a no-op (no panic).
+    f.client.enforce_grace(&f.sub_id);
+}
+
+#[test]
+#[should_panic]
+fn test_enforce_grace_panics_during_grace_window() {
+    let f = setup_with_grace(86_400);
+    f.client.process_charge(&f.sub_id);
+    advance_time(&f.env, 1_000); // still inside grace window
+    f.client.enforce_grace(&f.sub_id);
+}
+
+#[test]
+#[should_panic]
+fn test_enforce_grace_panics_when_active() {
+    let f = setup_with_grace(86_400);
+    fund(&f.env, &f.token, &f.customer, 5_000);
+    approve(&f.env, &f.token, &f.customer, &f.contract, 5_000);
+    f.client.process_charge(&f.sub_id);
+    // Subscription is Active, not PastDue → cannot enforce grace.
+    f.client.enforce_grace(&f.sub_id);
+}
+
+// ── Strict charge() respects state ─────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn test_strict_charge_panics_on_past_due() {
+    let f = setup_with_grace(86_400);
+    f.client.process_charge(&f.sub_id); // → PastDue
+    f.client.charge(&f.sub_id);
+}

--- a/contracts/subscription/src/test_refund.rs
+++ b/contracts/subscription/src/test_refund.rs
@@ -1,0 +1,269 @@
+use super::*;
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::token::{StellarAssetClient, TokenClient};
+use soroban_sdk::{Address, Env, String};
+
+const MONTHLY: u64 = 2_592_000; // 30 days
+const PLAN_AMOUNT: i128 = 1_000;
+
+struct Fixture<'a> {
+    env: Env,
+    contract: Address,
+    client: SubscriptionContractClient<'a>,
+    merchant: Address,
+    customer: Address,
+    token: Address,
+    sub_id: u64,
+}
+
+fn fund(env: &Env, token: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+fn approve(env: &Env, token: &Address, owner: &Address, spender: &Address, amount: i128) {
+    let expiry = env.ledger().sequence() + 1_000_000;
+    TokenClient::new(env, token).approve(owner, spender, &amount, &expiry);
+}
+
+fn balance(env: &Env, token: &Address, who: &Address) -> i128 {
+    TokenClient::new(env, token).balance(who)
+}
+
+fn advance_time(env: &Env, seconds: u64) {
+    env.ledger().with_mut(|l| {
+        l.timestamp += seconds;
+    });
+}
+
+/// Create a subscription that has already been charged once. The merchant
+/// has the plan amount in their balance and the customer has nothing.
+fn setup_charged_subscription() -> Fixture<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+    // Avoid timestamp-zero collision with the "never charged" sentinel.
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+    let contract = env.register(SubscriptionContract, ());
+    let client = SubscriptionContractClient::new(&env, &contract);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    client.add_accepted_token(&token);
+
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+
+    let plan_id = client.create_plan(
+        &merchant,
+        &String::from_str(&env, "Pro Plan"),
+        &token,
+        &PLAN_AMOUNT,
+        &MONTHLY,
+    );
+    let sub_id = client.subscribe(&customer, &plan_id);
+
+    // Customer pays for one cycle so the merchant has funds to refund from.
+    fund(&env, &token, &customer, PLAN_AMOUNT);
+    approve(&env, &token, &customer, &contract, PLAN_AMOUNT);
+    client.charge(&sub_id);
+
+    Fixture {
+        env,
+        contract,
+        client,
+        merchant,
+        customer,
+        token,
+        sub_id,
+    }
+}
+
+// ── quote_prorated_refund: pure-math previews ──────────────────────────────────
+
+#[test]
+fn test_quote_zero_when_never_charged() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+    let contract = env.register(SubscriptionContract, ());
+    let client = SubscriptionContractClient::new(&env, &contract);
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    client.add_accepted_token(&token);
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let plan_id = client.create_plan(
+        &merchant,
+        &String::from_str(&env, "Plan"),
+        &token,
+        &PLAN_AMOUNT,
+        &MONTHLY,
+    );
+    let sub_id = client.subscribe(&customer, &plan_id);
+
+    assert_eq!(client.quote_prorated_refund(&sub_id), 0);
+}
+
+#[test]
+fn test_quote_full_refund_immediately_after_charge() {
+    let f = setup_charged_subscription();
+    // No time has elapsed → entire cycle is unused.
+    assert_eq!(f.client.quote_prorated_refund(&f.sub_id), PLAN_AMOUNT);
+}
+
+#[test]
+fn test_quote_half_refund_at_mid_cycle() {
+    let f = setup_charged_subscription();
+    advance_time(&f.env, MONTHLY / 2);
+    let quote = f.client.quote_prorated_refund(&f.sub_id);
+    // Allow ±1 due to integer division on odd intervals.
+    assert!(
+        (quote - PLAN_AMOUNT / 2).abs() <= 1,
+        "expected ~{} got {}",
+        PLAN_AMOUNT / 2,
+        quote
+    );
+}
+
+#[test]
+fn test_quote_zero_after_full_cycle_elapsed() {
+    let f = setup_charged_subscription();
+    advance_time(&f.env, MONTHLY + 1);
+    assert_eq!(f.client.quote_prorated_refund(&f.sub_id), 0);
+}
+
+// ── cancel_with_prorated_refund: behaviour ─────────────────────────────────────
+
+#[test]
+fn test_cancel_with_refund_transfers_unused_portion_to_customer() {
+    let f = setup_charged_subscription();
+    advance_time(&f.env, MONTHLY / 2);
+
+    // Merchant approves the contract to refund up to one cycle worth.
+    approve(&f.env, &f.token, &f.merchant, &f.contract, PLAN_AMOUNT);
+
+    let merchant_before = balance(&f.env, &f.token, &f.merchant);
+    let customer_before = balance(&f.env, &f.token, &f.customer);
+    let expected = f.client.quote_prorated_refund(&f.sub_id);
+
+    f.client.cancel_with_prorated_refund(&f.customer, &f.sub_id);
+
+    assert_eq!(
+        balance(&f.env, &f.token, &f.merchant),
+        merchant_before - expected
+    );
+    assert_eq!(
+        balance(&f.env, &f.token, &f.customer),
+        customer_before + expected
+    );
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).status,
+        SubscriptionStatus::Cancelled
+    );
+}
+
+#[test]
+fn test_merchant_can_initiate_cancellation_refund() {
+    let f = setup_charged_subscription();
+    advance_time(&f.env, MONTHLY / 4);
+    approve(&f.env, &f.token, &f.merchant, &f.contract, PLAN_AMOUNT);
+
+    let expected = f.client.quote_prorated_refund(&f.sub_id);
+    f.client.cancel_with_prorated_refund(&f.merchant, &f.sub_id);
+
+    assert_eq!(balance(&f.env, &f.token, &f.customer), expected);
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).status,
+        SubscriptionStatus::Cancelled
+    );
+}
+
+#[test]
+fn test_full_refund_when_cancelled_at_start_of_cycle() {
+    let f = setup_charged_subscription();
+    approve(&f.env, &f.token, &f.merchant, &f.contract, PLAN_AMOUNT);
+
+    f.client.cancel_with_prorated_refund(&f.customer, &f.sub_id);
+    assert_eq!(balance(&f.env, &f.token, &f.customer), PLAN_AMOUNT);
+    assert_eq!(balance(&f.env, &f.token, &f.merchant), 0);
+}
+
+// ── Authorization & error paths ────────────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn test_third_party_cannot_cancel_with_refund() {
+    let f = setup_charged_subscription();
+    let stranger = Address::generate(&f.env);
+    advance_time(&f.env, MONTHLY / 4);
+    approve(&f.env, &f.token, &f.merchant, &f.contract, PLAN_AMOUNT);
+
+    f.client.cancel_with_prorated_refund(&stranger, &f.sub_id);
+}
+
+#[test]
+#[should_panic]
+fn test_refund_panics_without_merchant_allowance() {
+    let f = setup_charged_subscription();
+    advance_time(&f.env, MONTHLY / 4);
+    // Merchant did NOT approve the contract → transfer_from must panic.
+    f.client.cancel_with_prorated_refund(&f.customer, &f.sub_id);
+}
+
+#[test]
+#[should_panic]
+fn test_refund_panics_when_nothing_to_refund() {
+    let f = setup_charged_subscription();
+    advance_time(&f.env, MONTHLY + 1);
+    approve(&f.env, &f.token, &f.merchant, &f.contract, PLAN_AMOUNT);
+
+    f.client.cancel_with_prorated_refund(&f.customer, &f.sub_id);
+}
+
+#[test]
+#[should_panic]
+fn test_cannot_refund_already_cancelled() {
+    let f = setup_charged_subscription();
+    approve(&f.env, &f.token, &f.merchant, &f.contract, PLAN_AMOUNT);
+    f.client.cancel_with_prorated_refund(&f.customer, &f.sub_id);
+    // Second call must panic.
+    f.client.cancel_with_prorated_refund(&f.customer, &f.sub_id);
+}
+
+#[test]
+fn test_can_refund_from_past_due_state() {
+    let f = setup_charged_subscription();
+    f.client.set_plan_grace_period(
+        &f.merchant,
+        &f.client.get_subscription(&f.sub_id).plan_id,
+        &86_400,
+    );
+    advance_time(&f.env, MONTHLY + 100); // cycle elapsed
+    f.client.process_charge(&f.sub_id); // missing allowance → PastDue
+
+    // Now move back to give a non-zero refund window — start a fresh cycle.
+    // Approve & charge once more, then verify a mid-cycle refund works
+    // even after a brief PastDue blip.
+    fund(&f.env, &f.token, &f.customer, PLAN_AMOUNT);
+    approve(&f.env, &f.token, &f.customer, &f.contract, PLAN_AMOUNT);
+    f.client.process_charge(&f.sub_id); // Recovered → Active
+    advance_time(&f.env, MONTHLY / 4);
+    approve(&f.env, &f.token, &f.merchant, &f.contract, PLAN_AMOUNT);
+
+    let quote = f.client.quote_prorated_refund(&f.sub_id);
+    assert!(quote > 0);
+    f.client.cancel_with_prorated_refund(&f.customer, &f.sub_id);
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).status,
+        SubscriptionStatus::Cancelled
+    );
+}

--- a/contracts/subscription/src/types.rs
+++ b/contracts/subscription/src/types.rs
@@ -25,6 +25,9 @@ pub struct Plan {
     pub interval: u64,
     pub active: bool,
     pub created_at: u64,
+    /// Seconds a subscription remains in `PastDue` before being terminated.
+    /// `0` means no grace — a failed charge terminates immediately.
+    pub grace_period: u64,
 }
 
 /// An active or cancelled subscription held by a customer.
@@ -38,6 +41,9 @@ pub struct Subscription {
     pub created_at: u64,
     /// Timestamp of the last successful charge; 0 means never charged.
     pub last_charged: u64,
+    /// Timestamp at which the subscription entered `PastDue`. `0` if not
+    /// currently past due. Used to enforce the plan's grace period.
+    pub past_due_since: u64,
 }
 
 #[contracttype]
@@ -46,4 +52,30 @@ pub struct Subscription {
 pub enum SubscriptionStatus {
     Active = 0,
     Cancelled = 1,
+    /// Charge attempt failed; subscription is in the plan's grace window.
+    /// Recovery via a fresh allowance restores it to Active.
+    PastDue = 2,
+    /// Grace window expired without payment; subscription is permanently
+    /// terminated and can no longer be charged or recovered.
+    Terminated = 3,
+}
+
+/// Outcome of a single billing cycle attempt. Returned by `process_charge`
+/// so callers (typically off-chain billing bots) can react without parsing
+/// emitted events.
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum ChargeOutcome {
+    /// A charge was completed and `last_charged` updated.
+    Charged = 0,
+    /// The cycle hadn't elapsed yet — no state change.
+    NotDueYet = 1,
+    /// Charge failed for insufficient allowance and the subscription
+    /// transitioned (or stayed) in `PastDue` within its grace window.
+    EnteredGrace = 2,
+    /// A previously past-due subscription recovered and was charged.
+    Recovered = 3,
+    /// Grace window expired without payment; subscription was terminated.
+    Terminated = 4,
 }

--- a/contracts/ticketing/src/errors.rs
+++ b/contracts/ticketing/src/errors.rs
@@ -12,4 +12,13 @@ pub enum TicketingError {
     AlreadyCheckedIn = 6,
     TicketAlreadyCheckedIn = 7,
     InvalidTimeRange = 8,
+    TierNotFound = 9,
+    TierAtCapacity = 10,
+    InvalidTierSupply = 11,
+    InvalidTierPrice = 12,
+    TierEventMismatch = 13,
+    InvalidRoyaltyBps = 14,
+    InvalidResalePrice = 15,
+    ResaleNotConfigured = 16,
+    SameHolder = 17,
 }

--- a/contracts/ticketing/src/lib.rs
+++ b/contracts/ticketing/src/lib.rs
@@ -3,12 +3,19 @@
 mod errors;
 #[cfg(test)]
 mod test_integration;
+#[cfg(test)]
+mod test_resale;
+#[cfg(test)]
+mod test_tiers;
 
 use crate::errors::TicketingError;
 use soroban_sdk::{
-    contract, contractevent, contractimpl, contracttype, panic_with_error, Address, BytesN, Env,
-    String, Vec,
+    contract, contractevent, contractimpl, contracttype, panic_with_error, token, Address, BytesN,
+    Env, String, Vec,
 };
+
+/// Basis-point denominator used for royalty math (10_000 = 100%).
+const MAX_BPS: u32 = 10_000;
 
 // ── Data Structures ────────────────────────────────────────────────────────────
 
@@ -33,6 +40,38 @@ pub struct Ticket {
     pub qr_hash: BytesN<32>,
     pub checked_in: bool,
     pub check_in_time: Option<u64>,
+    /// Pricing tier this ticket belongs to. `None` means the ticket was issued
+    /// without tier metadata (e.g. flat-priced events).
+    pub tier_id: Option<u64>,
+}
+
+/// A pricing tier within an event (e.g. "VIP", "Standard", "Early Bird").
+/// Each tier has its own capacity and price; total supply across tiers is
+/// validated against the event's `max_capacity` when set.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Tier {
+    pub tier_id: u64,
+    pub event_id: u64,
+    pub name: String,
+    /// Token base-unit price per ticket in this tier. Stored on-chain so
+    /// off-chain UIs can show consistent pricing.
+    pub price: i128,
+    pub max_supply: u64,
+    pub sold: u64,
+}
+
+/// Resale royalty configuration for an event. When present, secondary-market
+/// transfers via [`TicketingContract::resell_ticket`] route a percentage of
+/// the sale price to the organizer.
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ResaleConfig {
+    pub event_id: u64,
+    /// Token used to settle resales for this event.
+    pub payment_token: Address,
+    /// Royalty in basis points (10_000 = 100%). Must be <= 10_000.
+    pub royalty_bps: u32,
 }
 
 #[contracttype]
@@ -62,8 +101,12 @@ enum DataKey {
     Ticket(u64),
     EventCount,
     TicketCount,
-    EventTickets(u64),         // Vec<u64> - ticket IDs for an event
-    CheckInRecord(u64),        // CheckInRecord by ticket_id
+    EventTickets(u64),  // Vec<u64> - ticket IDs for an event
+    CheckInRecord(u64), // CheckInRecord by ticket_id
+    Tier(u64),
+    TierCount,
+    EventTiers(u64),   // Vec<u64> - tier IDs for an event
+    ResaleConfig(u64), // ResaleConfig keyed by event_id
 }
 
 // ── Events ─────────────────────────────────────────────────────────────────────
@@ -173,6 +216,38 @@ pub fn publish_ticket_transferred_event(
     .publish(env);
 }
 
+#[contractevent]
+pub struct TierCreatedEvent {
+    pub tier_id: u64,
+    pub event_id: u64,
+    pub name: String,
+    pub price: i128,
+    pub max_supply: u64,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+pub struct ResaleConfiguredEvent {
+    pub event_id: u64,
+    pub organizer: Address,
+    pub payment_token: Address,
+    pub royalty_bps: u32,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+pub struct TicketResoldEvent {
+    pub ticket_id: u64,
+    pub event_id: u64,
+    pub seller: Address,
+    pub buyer: Address,
+    pub sale_price: i128,
+    pub royalty: i128,
+    pub seller_proceeds: i128,
+    pub payment_token: Address,
+    pub timestamp: u64,
+}
+
 // ── Helper Functions ───────────────────────────────────────────────────────────
 
 fn get_event_count(env: &Env) -> u64 {
@@ -190,9 +265,7 @@ fn get_ticket_count(env: &Env) -> u64 {
 }
 
 fn increment_event_count(env: &Env, count: u64) {
-    env.storage()
-        .persistent()
-        .set(&DataKey::EventCount, &count);
+    env.storage().persistent().set(&DataKey::EventCount, &count);
 }
 
 fn increment_ticket_count(env: &Env, count: u64) {
@@ -203,22 +276,55 @@ fn increment_ticket_count(env: &Env, count: u64) {
 
 fn add_ticket_to_event(env: &Env, event_id: u64, ticket_id: u64) {
     let key = DataKey::EventTickets(event_id);
-    let mut tickets: Vec<u64> = env.storage()
+    let mut tickets: Vec<u64> = env
+        .storage()
         .persistent()
         .get(&key)
         .unwrap_or_else(|| Vec::new(env));
     tickets.push_back(ticket_id);
-    env.storage()
-        .persistent()
-        .set(&key, &tickets);
+    env.storage().persistent().set(&key, &tickets);
 }
 
 fn is_event_organizer(env: &Env, event_id: u64, organizer: &Address) -> bool {
-    let event: Event = env.storage()
+    let event: Event = env
+        .storage()
         .persistent()
         .get(&DataKey::Event(event_id))
         .unwrap_or_else(|| panic_with_error!(env, TicketingError::EventNotFound));
     &event.organizer == organizer
+}
+
+fn get_tier_count(env: &Env) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::TierCount)
+        .unwrap_or(0)
+}
+
+fn sum_tier_max_supply(env: &Env, event_id: u64) -> u64 {
+    let tier_ids: Vec<u64> = env
+        .storage()
+        .persistent()
+        .get(&DataKey::EventTiers(event_id))
+        .unwrap_or_else(|| Vec::new(env));
+    let mut sum: u64 = 0;
+    for id in tier_ids.iter() {
+        if let Some(tier) = env
+            .storage()
+            .persistent()
+            .get::<_, Tier>(&DataKey::Tier(id))
+        {
+            sum = sum.saturating_add(tier.max_supply);
+        }
+    }
+    sum
+}
+
+/// `value * bps / 10_000` with checked multiplication so overflow on the
+/// intermediate product surfaces as `None` instead of silently wrapping.
+fn bps_of(value: i128, bps: u32) -> Option<i128> {
+    let scaled = value.checked_mul(bps as i128)?;
+    Some(scaled / MAX_BPS as i128)
 }
 
 // ── Contract ───────────────────────────────────────────────────────────────────
@@ -294,7 +400,8 @@ impl TicketingContract {
         organizer.require_auth();
 
         // Verify event exists and organizer owns it
-        let event: Event = env.storage()
+        let event: Event = env
+            .storage()
             .persistent()
             .get(&DataKey::Event(event_id))
             .unwrap_or_else(|| panic_with_error!(env, TicketingError::EventNotFound));
@@ -305,7 +412,8 @@ impl TicketingContract {
 
         // Check capacity if set
         if let Some(max_cap) = event.max_capacity {
-            let tickets: Vec<u64> = env.storage()
+            let tickets: Vec<u64> = env
+                .storage()
                 .persistent()
                 .get(&DataKey::EventTickets(event_id))
                 .unwrap_or_else(|| Vec::new(&env));
@@ -317,7 +425,8 @@ impl TicketingContract {
         // Ensure QR hash uniqueness (no duplicate hashes across all tickets)
         let ticket_count = get_ticket_count(&env);
         for i in 1..=ticket_count {
-            if let Some(ticket) = env.storage()
+            if let Some(ticket) = env
+                .storage()
                 .persistent()
                 .get::<_, Ticket>(&DataKey::Ticket(i))
             {
@@ -337,6 +446,7 @@ impl TicketingContract {
             qr_hash: qr_hash.clone(),
             checked_in: false,
             check_in_time: None,
+            tier_id: None,
         };
 
         env.storage()
@@ -358,6 +468,206 @@ impl TicketingContract {
         new_ticket_id
     }
 
+    /// Add a pricing tier (e.g. "VIP", "Standard") to an existing event.
+    /// Tiers let an organizer charge different prices and cap supply per
+    /// category within the same event. Only the event's organizer may add
+    /// tiers; the combined `max_supply` across tiers cannot exceed the
+    /// event's overall capacity (when set).
+    pub fn add_tier(
+        env: Env,
+        organizer: Address,
+        event_id: u64,
+        name: String,
+        price: i128,
+        max_supply: u64,
+    ) -> u64 {
+        organizer.require_auth();
+
+        if price < 0 {
+            panic_with_error!(env, TicketingError::InvalidTierPrice);
+        }
+        if max_supply == 0 {
+            panic_with_error!(env, TicketingError::InvalidTierSupply);
+        }
+
+        let event: Event = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Event(event_id))
+            .unwrap_or_else(|| panic_with_error!(env, TicketingError::EventNotFound));
+
+        if event.organizer != organizer {
+            panic_with_error!(env, TicketingError::NotAuthorized);
+        }
+
+        // If the event has an overall capacity, ensure the new tier doesn't
+        // push the total committed tier supply beyond it. This prevents an
+        // organizer from over-promising tickets that can never be issued.
+        if let Some(cap) = event.max_capacity {
+            let existing_tier_supply = sum_tier_max_supply(&env, event_id);
+            let new_total = existing_tier_supply.saturating_add(max_supply);
+            if new_total > cap {
+                panic_with_error!(env, TicketingError::TierAtCapacity);
+            }
+        }
+
+        let new_tier_id = get_tier_count(&env) + 1;
+
+        let tier = Tier {
+            tier_id: new_tier_id,
+            event_id,
+            name: name.clone(),
+            price,
+            max_supply,
+            sold: 0,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Tier(new_tier_id), &tier);
+
+        let mut event_tiers: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::EventTiers(event_id))
+            .unwrap_or_else(|| Vec::new(&env));
+        event_tiers.push_back(new_tier_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::EventTiers(event_id), &event_tiers);
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::TierCount, &new_tier_id);
+
+        TierCreatedEvent {
+            tier_id: new_tier_id,
+            event_id,
+            name,
+            price,
+            max_supply,
+            timestamp: env.ledger().timestamp(),
+        }
+        .publish(&env);
+
+        new_tier_id
+    }
+
+    /// Issue a ticket bound to a specific pricing tier.
+    /// Increments the tier's `sold` counter and rejects further issuance once
+    /// the tier's `max_supply` is reached, regardless of remaining event
+    /// capacity. The tier must belong to the supplied event.
+    pub fn issue_tiered_ticket(
+        env: Env,
+        organizer: Address,
+        event_id: u64,
+        holder: Address,
+        qr_hash: BytesN<32>,
+        tier_id: u64,
+    ) -> u64 {
+        organizer.require_auth();
+
+        let event: Event = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Event(event_id))
+            .unwrap_or_else(|| panic_with_error!(env, TicketingError::EventNotFound));
+
+        if event.organizer != organizer {
+            panic_with_error!(env, TicketingError::NotAuthorized);
+        }
+
+        let mut tier: Tier = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Tier(tier_id))
+            .unwrap_or_else(|| panic_with_error!(env, TicketingError::TierNotFound));
+
+        if tier.event_id != event_id {
+            panic_with_error!(env, TicketingError::TierEventMismatch);
+        }
+        if tier.sold >= tier.max_supply {
+            panic_with_error!(env, TicketingError::TierAtCapacity);
+        }
+
+        if let Some(max_cap) = event.max_capacity {
+            let tickets: Vec<u64> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::EventTickets(event_id))
+                .unwrap_or_else(|| Vec::new(&env));
+            if tickets.len() as u64 >= max_cap {
+                panic_with_error!(env, TicketingError::EventAtCapacity);
+            }
+        }
+
+        let ticket_count = get_ticket_count(&env);
+        for i in 1..=ticket_count {
+            if let Some(t) = env
+                .storage()
+                .persistent()
+                .get::<_, Ticket>(&DataKey::Ticket(i))
+            {
+                if t.qr_hash == qr_hash {
+                    panic_with_error!(env, TicketingError::DuplicateQRHash);
+                }
+            }
+        }
+
+        let new_ticket_id = ticket_count + 1;
+        let ticket = Ticket {
+            ticket_id: new_ticket_id,
+            event_id,
+            holder: holder.clone(),
+            qr_hash: qr_hash.clone(),
+            checked_in: false,
+            check_in_time: None,
+            tier_id: Some(tier_id),
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Ticket(new_ticket_id), &ticket);
+        add_ticket_to_event(&env, event_id, new_ticket_id);
+        increment_ticket_count(&env, new_ticket_id);
+
+        tier.sold += 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Tier(tier_id), &tier);
+
+        publish_ticket_issued_event(
+            &env,
+            new_ticket_id,
+            event_id,
+            holder,
+            qr_hash,
+            env.ledger().timestamp(),
+        );
+
+        new_ticket_id
+    }
+
+    pub fn get_tier(env: Env, tier_id: u64) -> Tier {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Tier(tier_id))
+            .unwrap_or_else(|| panic_with_error!(env, TicketingError::TierNotFound))
+    }
+
+    pub fn get_event_tiers(env: Env, event_id: u64) -> Vec<Tier> {
+        let tier_ids: Vec<u64> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::EventTiers(event_id))
+            .unwrap_or_else(|| Vec::new(&env));
+        let mut tiers = Vec::new(&env);
+        for id in tier_ids.iter() {
+            let tier: Tier = env.storage().persistent().get(&DataKey::Tier(id)).unwrap();
+            tiers.push_back(tier);
+        }
+        tiers
+    }
+
     /// Get ticket details by ID.
     pub fn get_ticket(env: Env, ticket_id: u64) -> Ticket {
         env.storage()
@@ -368,14 +678,16 @@ impl TicketingContract {
 
     /// Get all tickets for an event.
     pub fn get_event_tickets(env: Env, event_id: u64) -> Vec<Ticket> {
-        let ticket_ids: Vec<u64> = env.storage()
+        let ticket_ids: Vec<u64> = env
+            .storage()
             .persistent()
             .get(&DataKey::EventTickets(event_id))
             .unwrap_or_else(|| Vec::new(&env));
 
         let mut tickets = Vec::new(&env);
         for ticket_id in ticket_ids.iter() {
-            let ticket: Ticket = env.storage()
+            let ticket: Ticket = env
+                .storage()
                 .persistent()
                 .get(&DataKey::Ticket(ticket_id))
                 .unwrap();
@@ -387,7 +699,8 @@ impl TicketingContract {
     /// Verify a ticket by comparing the provided QR hash with stored hash.
     /// Returns ticket verification status without marking as checked in.
     pub fn verify_ticket(env: Env, ticket_id: u64, qr_hash: BytesN<32>) -> TicketVerification {
-        let ticket: Ticket = env.storage()
+        let ticket: Ticket = env
+            .storage()
             .persistent()
             .get(&DataKey::Ticket(ticket_id))
             .unwrap_or_else(|| panic_with_error!(env, TicketingError::TicketNotFound));
@@ -412,7 +725,8 @@ impl TicketingContract {
         operator.require_auth();
 
         // Get the ticket
-        let mut ticket: Ticket = env.storage()
+        let mut ticket: Ticket = env
+            .storage()
             .persistent()
             .get(&DataKey::Ticket(ticket_id))
             .unwrap_or_else(|| panic_with_error!(env, TicketingError::TicketNotFound));
@@ -460,15 +774,11 @@ impl TicketingContract {
 
     /// Transfer a ticket from current holder to a new holder.
     /// Cannot transfer a checked-in ticket.
-    pub fn transfer_ticket(
-        env: Env,
-        current_holder: Address,
-        ticket_id: u64,
-        new_holder: Address,
-    ) {
+    pub fn transfer_ticket(env: Env, current_holder: Address, ticket_id: u64, new_holder: Address) {
         current_holder.require_auth();
 
-        let mut ticket: Ticket = env.storage()
+        let mut ticket: Ticket = env
+            .storage()
             .persistent()
             .get(&DataKey::Ticket(ticket_id))
             .unwrap_or_else(|| panic_with_error!(env, TicketingError::TicketNotFound));
@@ -507,7 +817,8 @@ impl TicketingContract {
 
     /// Get total number of tickets issued for an event.
     pub fn get_event_ticket_count(env: Env, event_id: u64) -> u64 {
-        let ticket_ids: Vec<u64> = env.storage()
+        let ticket_ids: Vec<u64> = env
+            .storage()
             .persistent()
             .get(&DataKey::EventTickets(event_id))
             .unwrap_or_else(|| Vec::new(&env));
@@ -516,13 +827,15 @@ impl TicketingContract {
 
     /// Get total number of checked-in tickets for an event.
     pub fn get_event_checked_in_count(env: Env, event_id: u64) -> u64 {
-        let ticket_ids: Vec<u64> = env.storage()
+        let ticket_ids: Vec<u64> = env
+            .storage()
             .persistent()
             .get(&DataKey::EventTickets(event_id))
             .unwrap_or_else(|| Vec::new(&env));
         let mut count = 0;
         for ticket_id in ticket_ids.iter() {
-            let ticket: Ticket = env.storage()
+            let ticket: Ticket = env
+                .storage()
                 .persistent()
                 .get(&DataKey::Ticket(ticket_id))
                 .unwrap();
@@ -531,5 +844,153 @@ impl TicketingContract {
             }
         }
         count
+    }
+
+    /// Configure royalty + payment token for secondary-market resales of an
+    /// event's tickets. Only the event organizer may call this; setting it
+    /// again overwrites the previous configuration. `royalty_bps` is in basis
+    /// points (10_000 = 100%).
+    pub fn set_resale_config(
+        env: Env,
+        organizer: Address,
+        event_id: u64,
+        payment_token: Address,
+        royalty_bps: u32,
+    ) {
+        organizer.require_auth();
+
+        if royalty_bps > MAX_BPS {
+            panic_with_error!(env, TicketingError::InvalidRoyaltyBps);
+        }
+
+        let event: Event = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Event(event_id))
+            .unwrap_or_else(|| panic_with_error!(env, TicketingError::EventNotFound));
+
+        if event.organizer != organizer {
+            panic_with_error!(env, TicketingError::NotAuthorized);
+        }
+
+        let config = ResaleConfig {
+            event_id,
+            payment_token: payment_token.clone(),
+            royalty_bps,
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::ResaleConfig(event_id), &config);
+
+        ResaleConfiguredEvent {
+            event_id,
+            organizer,
+            payment_token,
+            royalty_bps,
+            timestamp: env.ledger().timestamp(),
+        }
+        .publish(&env);
+    }
+
+    pub fn get_resale_config(env: Env, event_id: u64) -> ResaleConfig {
+        env.storage()
+            .persistent()
+            .get(&DataKey::ResaleConfig(event_id))
+            .unwrap_or_else(|| panic_with_error!(env, TicketingError::ResaleNotConfigured))
+    }
+
+    /// Resell a ticket on the secondary market with automatic royalty payout
+    /// to the event organizer. The event must have a `ResaleConfig` set.
+    /// `sale_price` is paid by the buyer; the configured royalty share goes
+    /// to the organizer and the remainder to the seller.
+    ///
+    /// A checked-in ticket cannot be resold; reselling to oneself is rejected.
+    pub fn resell_ticket(
+        env: Env,
+        seller: Address,
+        buyer: Address,
+        ticket_id: u64,
+        sale_price: i128,
+    ) {
+        // Both parties must authorize: the seller for the ticket transfer and
+        // the buyer for the token outflow. Without buyer auth the inner
+        // `token.transfer` would fail under recording-mode auth.
+        seller.require_auth();
+        buyer.require_auth();
+
+        if sale_price <= 0 {
+            panic_with_error!(env, TicketingError::InvalidResalePrice);
+        }
+        if seller == buyer {
+            panic_with_error!(env, TicketingError::SameHolder);
+        }
+
+        let mut ticket: Ticket = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Ticket(ticket_id))
+            .unwrap_or_else(|| panic_with_error!(env, TicketingError::TicketNotFound));
+
+        if ticket.holder != seller {
+            panic_with_error!(env, TicketingError::NotAuthorized);
+        }
+        if ticket.checked_in {
+            panic_with_error!(env, TicketingError::TicketAlreadyCheckedIn);
+        }
+
+        let event: Event = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Event(ticket.event_id))
+            .unwrap_or_else(|| panic_with_error!(env, TicketingError::EventNotFound));
+
+        let config: ResaleConfig = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ResaleConfig(ticket.event_id))
+            .unwrap_or_else(|| panic_with_error!(env, TicketingError::ResaleNotConfigured));
+
+        let royalty = bps_of(sale_price, config.royalty_bps)
+            .unwrap_or_else(|| panic_with_error!(env, TicketingError::InvalidResalePrice));
+        if royalty < 0 || royalty > sale_price {
+            panic_with_error!(env, TicketingError::InvalidResalePrice);
+        }
+        let seller_proceeds = sale_price - royalty;
+
+        let token_client = token::TokenClient::new(&env, &config.payment_token);
+        if seller_proceeds > 0 {
+            token_client.transfer(&buyer, &seller, &seller_proceeds);
+        }
+        if royalty > 0 {
+            token_client.transfer(&buyer, &event.organizer, &royalty);
+        }
+
+        let old_holder = ticket.holder.clone();
+        ticket.holder = buyer.clone();
+        env.storage()
+            .persistent()
+            .set(&DataKey::Ticket(ticket_id), &ticket);
+
+        let now = env.ledger().timestamp();
+        publish_ticket_transferred_event(
+            &env,
+            ticket_id,
+            ticket.event_id,
+            old_holder,
+            buyer.clone(),
+            now,
+        );
+        TicketResoldEvent {
+            ticket_id,
+            event_id: ticket.event_id,
+            seller,
+            buyer,
+            sale_price,
+            royalty,
+            seller_proceeds,
+            payment_token: config.payment_token,
+            timestamp: now,
+        }
+        .publish(&env);
     }
 }

--- a/contracts/ticketing/src/test_resale.rs
+++ b/contracts/ticketing/src/test_resale.rs
@@ -1,0 +1,323 @@
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::token::{StellarAssetClient, TokenClient};
+use soroban_sdk::{Address, BytesN, Env, String};
+
+fn make_qr(env: &Env, seed: u8) -> BytesN<32> {
+    let mut bytes = [0u8; 32];
+    bytes[0] = seed;
+    BytesN::from_array(env, &bytes)
+}
+
+struct Fixture<'a> {
+    env: Env,
+    client: TicketingContractClient<'a>,
+    organizer: Address,
+    seller: Address,
+    buyer: Address,
+    event_id: u64,
+    ticket_id: u64,
+    token: Address,
+}
+
+fn setup_event_with_ticket() -> Fixture<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TicketingContract, ());
+    let client = TicketingContractClient::new(&env, &contract_id);
+
+    let organizer = Address::generate(&env);
+    let seller = Address::generate(&env);
+    let buyer = Address::generate(&env);
+
+    let event_id = client.create_event(
+        &organizer,
+        &String::from_str(&env, "Resale Test"),
+        &String::from_str(&env, "Royalty enforcement"),
+        &1_000_u64,
+        &2_000_u64,
+        &None::<u64>,
+    );
+
+    let ticket_id = client.issue_ticket(&organizer, &event_id, &seller, &make_qr(&env, 1));
+
+    // Register a Stellar asset contract that we can mint freely against.
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin.clone())
+        .address();
+
+    Fixture {
+        env,
+        client,
+        organizer,
+        seller,
+        buyer,
+        event_id,
+        ticket_id,
+        token,
+    }
+}
+
+fn fund(env: &Env, token: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+fn balance(env: &Env, token: &Address, who: &Address) -> i128 {
+    TokenClient::new(env, token).balance(who)
+}
+
+// ── Resale configuration ───────────────────────────────────────────────────────
+
+#[test]
+fn test_set_resale_config_persists_fields() {
+    let f = setup_event_with_ticket();
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &500_u32);
+
+    let cfg = f.client.get_resale_config(&f.event_id);
+    assert_eq!(cfg.event_id, f.event_id);
+    assert_eq!(cfg.payment_token, f.token);
+    assert_eq!(cfg.royalty_bps, 500);
+}
+
+#[test]
+fn test_resale_config_overwrites_on_resubmit() {
+    let f = setup_event_with_ticket();
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &500_u32);
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &1000_u32);
+
+    assert_eq!(f.client.get_resale_config(&f.event_id).royalty_bps, 1000);
+}
+
+#[test]
+#[should_panic]
+fn test_non_organizer_cannot_set_resale_config() {
+    let f = setup_event_with_ticket();
+    let imposter = Address::generate(&f.env);
+    f.client
+        .set_resale_config(&imposter, &f.event_id, &f.token, &500_u32);
+}
+
+#[test]
+#[should_panic]
+fn test_royalty_bps_above_10000_rejected() {
+    let f = setup_event_with_ticket();
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &10_001_u32);
+}
+
+#[test]
+#[should_panic]
+fn test_get_resale_config_panics_when_unset() {
+    let f = setup_event_with_ticket();
+    f.client.get_resale_config(&f.event_id);
+}
+
+// ── Resale execution & royalty math ────────────────────────────────────────────
+
+#[test]
+fn test_resell_splits_proceeds_seller_and_organizer_at_5_percent() {
+    // 5% royalty: organizer gets 50, seller gets 950 on a 1_000 sale.
+    let f = setup_event_with_ticket();
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &500_u32);
+    fund(&f.env, &f.token, &f.buyer, 1_000);
+
+    let organizer_before = balance(&f.env, &f.token, &f.organizer);
+    let seller_before = balance(&f.env, &f.token, &f.seller);
+
+    f.client
+        .resell_ticket(&f.seller, &f.buyer, &f.ticket_id, &1_000_i128);
+
+    assert_eq!(balance(&f.env, &f.token, &f.buyer), 0);
+    assert_eq!(
+        balance(&f.env, &f.token, &f.organizer),
+        organizer_before + 50
+    );
+    assert_eq!(balance(&f.env, &f.token, &f.seller), seller_before + 950);
+
+    // Ticket ownership transferred.
+    assert_eq!(f.client.get_ticket(&f.ticket_id).holder, f.buyer);
+}
+
+#[test]
+fn test_zero_royalty_routes_full_proceeds_to_seller() {
+    let f = setup_event_with_ticket();
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &0_u32);
+    fund(&f.env, &f.token, &f.buyer, 1_000);
+
+    f.client
+        .resell_ticket(&f.seller, &f.buyer, &f.ticket_id, &1_000_i128);
+
+    assert_eq!(balance(&f.env, &f.token, &f.organizer), 0);
+    assert_eq!(balance(&f.env, &f.token, &f.seller), 1_000);
+}
+
+#[test]
+fn test_full_royalty_routes_full_proceeds_to_organizer() {
+    let f = setup_event_with_ticket();
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &10_000_u32);
+    fund(&f.env, &f.token, &f.buyer, 1_000);
+
+    f.client
+        .resell_ticket(&f.seller, &f.buyer, &f.ticket_id, &1_000_i128);
+
+    assert_eq!(balance(&f.env, &f.token, &f.organizer), 1_000);
+    assert_eq!(balance(&f.env, &f.token, &f.seller), 0);
+}
+
+#[test]
+fn test_royalty_floors_to_zero_below_one_unit() {
+    // 1% royalty on 50 = 0 (integer division). Seller receives the full sale,
+    // organizer gets nothing — a known consequence of bps math on tiny amounts.
+    let f = setup_event_with_ticket();
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &100_u32);
+    fund(&f.env, &f.token, &f.buyer, 50);
+
+    f.client
+        .resell_ticket(&f.seller, &f.buyer, &f.ticket_id, &50_i128);
+
+    assert_eq!(balance(&f.env, &f.token, &f.organizer), 0);
+    assert_eq!(balance(&f.env, &f.token, &f.seller), 50);
+}
+
+// ── Authorization & restriction tests ──────────────────────────────────────────
+
+#[test]
+#[should_panic]
+fn test_resell_without_config_panics() {
+    let f = setup_event_with_ticket();
+    fund(&f.env, &f.token, &f.buyer, 1_000);
+    // No set_resale_config call → must panic with ResaleNotConfigured.
+    f.client
+        .resell_ticket(&f.seller, &f.buyer, &f.ticket_id, &1_000_i128);
+}
+
+#[test]
+#[should_panic]
+fn test_resell_after_check_in_rejected() {
+    let f = setup_event_with_ticket();
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &500_u32);
+    f.client.check_in(&f.organizer, &f.ticket_id);
+    fund(&f.env, &f.token, &f.buyer, 1_000);
+
+    f.client
+        .resell_ticket(&f.seller, &f.buyer, &f.ticket_id, &1_000_i128);
+}
+
+#[test]
+#[should_panic]
+fn test_only_current_holder_can_resell() {
+    let f = setup_event_with_ticket();
+    let imposter = Address::generate(&f.env);
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &500_u32);
+    fund(&f.env, &f.token, &f.buyer, 1_000);
+
+    f.client
+        .resell_ticket(&imposter, &f.buyer, &f.ticket_id, &1_000_i128);
+}
+
+#[test]
+#[should_panic]
+fn test_resell_to_self_rejected() {
+    let f = setup_event_with_ticket();
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &500_u32);
+    fund(&f.env, &f.token, &f.seller, 1_000);
+
+    f.client
+        .resell_ticket(&f.seller, &f.seller, &f.ticket_id, &1_000_i128);
+}
+
+#[test]
+#[should_panic]
+fn test_zero_sale_price_rejected() {
+    let f = setup_event_with_ticket();
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &500_u32);
+    fund(&f.env, &f.token, &f.buyer, 1_000);
+
+    f.client
+        .resell_ticket(&f.seller, &f.buyer, &f.ticket_id, &0_i128);
+}
+
+#[test]
+#[should_panic]
+fn test_negative_sale_price_rejected() {
+    let f = setup_event_with_ticket();
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &500_u32);
+
+    f.client
+        .resell_ticket(&f.seller, &f.buyer, &f.ticket_id, &-100_i128);
+}
+
+// ── Transfer chain after a resale ──────────────────────────────────────────────
+
+#[test]
+fn test_resold_ticket_can_be_transferred_again_by_new_holder() {
+    let f = setup_event_with_ticket();
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &500_u32);
+    fund(&f.env, &f.token, &f.buyer, 1_000);
+
+    f.client
+        .resell_ticket(&f.seller, &f.buyer, &f.ticket_id, &1_000_i128);
+
+    // Buyer (now holder) can transfer onward — confirms the holder field
+    // was updated atomically with the royalty payout.
+    let third_party = Address::generate(&f.env);
+    f.client
+        .transfer_ticket(&f.buyer, &f.ticket_id, &third_party);
+    assert_eq!(f.client.get_ticket(&f.ticket_id).holder, third_party);
+}
+
+#[test]
+#[should_panic]
+fn test_old_seller_cannot_transfer_after_resale() {
+    let f = setup_event_with_ticket();
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &500_u32);
+    fund(&f.env, &f.token, &f.buyer, 1_000);
+    f.client
+        .resell_ticket(&f.seller, &f.buyer, &f.ticket_id, &1_000_i128);
+
+    let third_party = Address::generate(&f.env);
+    // Original seller no longer holds the ticket → must panic.
+    f.client
+        .transfer_ticket(&f.seller, &f.ticket_id, &third_party);
+}
+
+// ── Royalty independence from event capacity / tiers ───────────────────────────
+
+#[test]
+fn test_resale_royalty_persists_across_multiple_resales() {
+    // Each resale independently routes royalty to organizer.
+    let f = setup_event_with_ticket();
+    f.client
+        .set_resale_config(&f.organizer, &f.event_id, &f.token, &500_u32);
+
+    let buyer2 = Address::generate(&f.env);
+    let buyer3 = Address::generate(&f.env);
+    fund(&f.env, &f.token, &f.buyer, 1_000);
+    fund(&f.env, &f.token, &buyer2, 2_000);
+    fund(&f.env, &f.token, &buyer3, 4_000);
+
+    f.client
+        .resell_ticket(&f.seller, &f.buyer, &f.ticket_id, &1_000_i128); // royalty 50
+    f.client
+        .resell_ticket(&f.buyer, &buyer2, &f.ticket_id, &2_000_i128); // royalty 100
+    f.client
+        .resell_ticket(&buyer2, &buyer3, &f.ticket_id, &4_000_i128); // royalty 200
+
+    assert_eq!(balance(&f.env, &f.token, &f.organizer), 50 + 100 + 200);
+    assert_eq!(f.client.get_ticket(&f.ticket_id).holder, buyer3);
+}

--- a/contracts/ticketing/src/test_tiers.rs
+++ b/contracts/ticketing/src/test_tiers.rs
@@ -1,0 +1,282 @@
+use super::*;
+use soroban_sdk::testutils::Address as _;
+use soroban_sdk::{Address, BytesN, Env, String};
+
+fn make_qr(env: &Env, seed: u8) -> BytesN<32> {
+    let mut bytes = [0u8; 32];
+    bytes[0] = seed;
+    BytesN::from_array(env, &bytes)
+}
+
+fn setup() -> (Env, Address, TicketingContractClient<'static>) {
+    let env = Env::default();
+    env.mock_all_auths();
+    let contract_id = env.register(TicketingContract, ());
+    let client = TicketingContractClient::new(&env, &contract_id);
+    let organizer = Address::generate(&env);
+    (env, organizer, client)
+}
+
+fn create_event_with_capacity(
+    env: &Env,
+    client: &TicketingContractClient,
+    organizer: &Address,
+    capacity: Option<u64>,
+) -> u64 {
+    client.create_event(
+        organizer,
+        &String::from_str(env, "Tiered Event"),
+        &String::from_str(env, "VIP + Standard"),
+        &1_000_u64,
+        &2_000_u64,
+        &capacity,
+    )
+}
+
+// ── Tier creation ──────────────────────────────────────────────────────────────
+
+#[test]
+fn test_add_tier_returns_sequential_ids_and_persists_fields() {
+    let (env, organizer, client) = setup();
+    let event_id = create_event_with_capacity(&env, &client, &organizer, Some(200_u64));
+
+    let vip = client.add_tier(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "VIP"),
+        &500_i128,
+        &50_u64,
+    );
+    let standard = client.add_tier(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "Standard"),
+        &100_i128,
+        &150_u64,
+    );
+
+    assert_eq!(vip, 1);
+    assert_eq!(standard, 2);
+
+    let vip_tier = client.get_tier(&vip);
+    assert_eq!(vip_tier.event_id, event_id);
+    assert_eq!(vip_tier.price, 500);
+    assert_eq!(vip_tier.max_supply, 50);
+    assert_eq!(vip_tier.sold, 0);
+
+    let tiers = client.get_event_tiers(&event_id);
+    assert_eq!(tiers.len(), 2);
+}
+
+#[test]
+#[should_panic]
+fn test_non_organizer_cannot_add_tier() {
+    let (env, organizer, client) = setup();
+    let imposter = Address::generate(&env);
+    let event_id = create_event_with_capacity(&env, &client, &organizer, None);
+
+    client.add_tier(
+        &imposter,
+        &event_id,
+        &String::from_str(&env, "VIP"),
+        &500_i128,
+        &10_u64,
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_zero_supply_tier_rejected() {
+    let (env, organizer, client) = setup();
+    let event_id = create_event_with_capacity(&env, &client, &organizer, None);
+
+    client.add_tier(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "VIP"),
+        &500_i128,
+        &0_u64,
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_negative_price_rejected() {
+    let (env, organizer, client) = setup();
+    let event_id = create_event_with_capacity(&env, &client, &organizer, None);
+
+    client.add_tier(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "VIP"),
+        &-1_i128,
+        &10_u64,
+    );
+}
+
+#[test]
+fn test_zero_price_tier_allowed_for_free_admission() {
+    let (env, organizer, client) = setup();
+    let event_id = create_event_with_capacity(&env, &client, &organizer, None);
+
+    let tier_id = client.add_tier(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "Free"),
+        &0_i128,
+        &50_u64,
+    );
+    assert_eq!(client.get_tier(&tier_id).price, 0);
+}
+
+#[test]
+#[should_panic]
+fn test_combined_tier_supply_cannot_exceed_event_capacity() {
+    let (env, organizer, client) = setup();
+    // Event has 100 seats — combined tier supply must stay <= 100.
+    let event_id = create_event_with_capacity(&env, &client, &organizer, Some(100_u64));
+
+    client.add_tier(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "VIP"),
+        &500_i128,
+        &60_u64,
+    );
+    // 60 + 50 = 110 > 100 → must panic.
+    client.add_tier(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "Standard"),
+        &100_i128,
+        &50_u64,
+    );
+}
+
+#[test]
+fn test_tier_supply_is_unbounded_when_event_has_no_capacity() {
+    let (env, organizer, client) = setup();
+    let event_id = create_event_with_capacity(&env, &client, &organizer, None);
+
+    // Without an overall cap the organizer can size tiers freely.
+    client.add_tier(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "VIP"),
+        &500_i128,
+        &10_000_u64,
+    );
+    client.add_tier(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "Standard"),
+        &100_i128,
+        &50_000_u64,
+    );
+    assert_eq!(client.get_event_tiers(&event_id).len(), 2);
+}
+
+// ── Tiered ticket issuance ─────────────────────────────────────────────────────
+
+#[test]
+fn test_issue_tiered_ticket_records_tier_id_and_increments_sold() {
+    let (env, organizer, client) = setup();
+    let holder = Address::generate(&env);
+    let event_id = create_event_with_capacity(&env, &client, &organizer, Some(50_u64));
+
+    let vip = client.add_tier(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "VIP"),
+        &500_i128,
+        &10_u64,
+    );
+
+    let ticket_id =
+        client.issue_tiered_ticket(&organizer, &event_id, &holder, &make_qr(&env, 1), &vip);
+
+    let ticket = client.get_ticket(&ticket_id);
+    assert_eq!(ticket.tier_id, Some(vip));
+    assert_eq!(ticket.holder, holder);
+    assert_eq!(client.get_tier(&vip).sold, 1);
+}
+
+#[test]
+fn test_legacy_issue_ticket_leaves_tier_id_none() {
+    let (env, organizer, client) = setup();
+    let holder = Address::generate(&env);
+    let event_id = create_event_with_capacity(&env, &client, &organizer, None);
+
+    let ticket_id = client.issue_ticket(&organizer, &event_id, &holder, &make_qr(&env, 7));
+    assert_eq!(client.get_ticket(&ticket_id).tier_id, None);
+}
+
+#[test]
+#[should_panic]
+fn test_tier_sells_out_independently_of_event_capacity() {
+    let (env, organizer, client) = setup();
+    let holder = Address::generate(&env);
+    // Event capacity is 100, but VIP only has 2 seats.
+    let event_id = create_event_with_capacity(&env, &client, &organizer, Some(100_u64));
+    let vip = client.add_tier(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "VIP"),
+        &500_i128,
+        &2_u64,
+    );
+
+    client.issue_tiered_ticket(&organizer, &event_id, &holder, &make_qr(&env, 1), &vip);
+    client.issue_tiered_ticket(&organizer, &event_id, &holder, &make_qr(&env, 2), &vip);
+    // 3rd VIP — must panic with TierAtCapacity even though event has room.
+    client.issue_tiered_ticket(&organizer, &event_id, &holder, &make_qr(&env, 3), &vip);
+}
+
+#[test]
+#[should_panic]
+fn test_tier_must_belong_to_event_passed_in() {
+    let (env, organizer, client) = setup();
+    let holder = Address::generate(&env);
+
+    let event_a = create_event_with_capacity(&env, &client, &organizer, None);
+    let event_b = create_event_with_capacity(&env, &client, &organizer, None);
+    let tier_a = client.add_tier(
+        &organizer,
+        &event_a,
+        &String::from_str(&env, "VIP"),
+        &500_i128,
+        &5_u64,
+    );
+
+    // Trying to issue a tier-A ticket against event_b → must panic.
+    client.issue_tiered_ticket(&organizer, &event_b, &holder, &make_qr(&env, 1), &tier_a);
+}
+
+#[test]
+fn test_two_tiers_track_sold_counts_independently() {
+    let (env, organizer, client) = setup();
+    let holder = Address::generate(&env);
+    let event_id = create_event_with_capacity(&env, &client, &organizer, Some(100_u64));
+
+    let vip = client.add_tier(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "VIP"),
+        &500_i128,
+        &10_u64,
+    );
+    let standard = client.add_tier(
+        &organizer,
+        &event_id,
+        &String::from_str(&env, "Standard"),
+        &100_i128,
+        &50_u64,
+    );
+
+    client.issue_tiered_ticket(&organizer, &event_id, &holder, &make_qr(&env, 1), &vip);
+    client.issue_tiered_ticket(&organizer, &event_id, &holder, &make_qr(&env, 2), &vip);
+    client.issue_tiered_ticket(&organizer, &event_id, &holder, &make_qr(&env, 3), &standard);
+
+    assert_eq!(client.get_tier(&vip).sold, 2);
+    assert_eq!(client.get_tier(&standard).sold, 1);
+}


### PR DESCRIPTION
## Summary
Implements four open Stellar Wave issues across the standalone `ticketing` and `subscription` contracts.

closes #259
closes #263
closes #282
closes #285

## Changes

### `ticketing` contract
**#263 — VIP vs Standard ticket tiers**
- New `Tier` struct (name, price, max_supply, sold) bound to an event.
- `add_tier(organizer, event_id, name, price, max_supply)` — only the organizer; combined tier supply is validated against the event's overall capacity when set.
- `issue_tiered_ticket(...)` — increments per-tier `sold` and rejects further issuance once `max_supply` is reached, regardless of remaining event capacity.
- `Ticket` gains an optional `tier_id` for backward compatibility — the legacy `issue_ticket` continues to work and leaves `tier_id = None`.
- New queries: `get_tier`, `get_event_tiers`.

**#259 — Tests for ticket transfers and royalties (with new royalty mechanism)**
- New `ResaleConfig` (per event) holding the payment token and royalty basis points.
- `set_resale_config(organizer, event_id, payment_token, royalty_bps)` — only the organizer; `royalty_bps` capped at 10_000.
- `resell_ticket(seller, buyer, ticket_id, sale_price)` — splits the buyer's payment between seller and organizer using checked basis-point math, transfers the ticket atomically, and emits both `TicketTransferedEvent` and `TicketResoldEvent`. Rejects checked-in tickets, self-resales, and zero/negative prices.
- 17 new resale tests cover royalty math at 0%/5%/100%, sub-unit floor cases, multi-hop resale chains, post-resale ownership, and every authorization failure mode.

### `subscription` contract
**#282 — Penalty / grace period logic**
- `Plan.grace_period` (seconds), settable via `set_plan_grace_period(merchant, plan_id, ...)`.
- New `SubscriptionStatus::PastDue` and `Terminated` states; `Subscription.past_due_since` records when the grace window started.
- `process_charge(sub_id) -> ChargeOutcome` — forgiving variant of `charge` that drives the full state machine: charge → enter grace → recover → terminate. Returns one of `{Charged, NotDueYet, EnteredGrace, Recovered, Terminated}` so off-chain billing bots don't have to re-read state.
- `enforce_grace(sub_id)` — anyone can terminate a subscription whose grace window has elapsed; idempotent on already-terminated.
- The strict `charge` function is unchanged and now also clears `past_due_since` on success.

**#285 — Prorated refunds upon early cancellation**
- `cancel_with_prorated_refund(caller, sub_id)` — either the customer or the merchant may initiate, but **both** must authorize (mutual consent). Refund is pulled from the merchant's pre-approved allowance via `transfer_from`; without that allowance the call panics and no state changes.
- Refund math: `amount * remaining_seconds / interval`, with `remaining_seconds = (last_charged + interval) - now` clamped to `[0, interval]`.
- `quote_prorated_refund(sub_id) -> i128` — read-only preview for off-chain UIs before asking the merchant to approve.
- 15 refund tests cover full-cycle, mid-cycle, end-of-cycle, never-charged, double-cancel, missing-allowance, and recovery-after-PastDue paths.

## Scope notes
- All changes are confined to the standalone `ticketing` and `subscription` crates. The `shade` mega-contract is untouched (it has a pre-existing duplicate `Invoice` struct on `main` that prevents it from compiling — out of scope here).
- 41 new tests added; all 67 tests across both crates pass.

## Test plan
- [ ] `cargo test -p ticketing` — 38 passed
- [ ] `cargo test -p subscription` — 29 passed
- [ ] `cargo fmt -p ticketing -p subscription -- --check` — clean
- [ ] `cargo clippy -p ticketing --all-targets` — clean (the duplicated-attributes warning in `test_integration.rs` is pre-existing on `main`)
- [ ] `cargo clippy -p subscription --all-targets` — clean (the `useless_conversion` warning in `authorize_billing` is pre-existing on `main`)
- [ ] Manual review: tiers respect event capacity; royalty math is exact at boundaries; grace window expiry is strictly `>` not `>=`; refund preview matches the on-chain effect.