### PR TITLE
feat(subscription): batch billing cycle and allowance-revoking cancel

### DIFF
--- a/contracts/subscription/src/lib.rs
+++ b/contracts/subscription/src/lib.rs
@@ -243,20 +243,44 @@ impl SubscriptionContract {
         load_subscription(&env, sub_id)
     }
 
+    /// Cancel a subscription, halting all future billing immediately.
+    ///
+    /// Either the customer or the plan's merchant may cancel, and a
+    /// subscription can be cancelled from `Active` or `PastDue` — letting
+    /// a customer in grace opt out without first having to recover.
+    ///
+    /// When the customer initiates, this also zeros the contract's
+    /// token allowance from the customer so any stale authorization is
+    /// removed in the same call. The merchant cannot unilaterally revoke
+    /// a customer's allowance (the token requires the owner's auth), so a
+    /// merchant-initiated cancel only flips the status — the customer
+    /// can call [`revoke_billing_authorization`] separately if desired,
+    /// though it's already a no-op since a cancelled subscription will
+    /// reject future charges regardless.
     pub fn cancel_subscription(env: Env, caller: Address, sub_id: u64) {
         caller.require_auth();
         let mut sub = load_subscription(&env, sub_id);
-        if sub.status != SubscriptionStatus::Active {
+        if sub.status != SubscriptionStatus::Active && sub.status != SubscriptionStatus::PastDue {
             panic_with_error!(&env, SubscriptionError::SubscriptionNotActive);
         }
         let plan = load_plan(&env, sub.plan_id);
-        if sub.customer != caller && plan.merchant != caller {
+        let is_customer = sub.customer == caller;
+        let is_merchant = plan.merchant == caller;
+        if !is_customer && !is_merchant {
             panic_with_error!(&env, SubscriptionError::NotAuthorized);
         }
+
         sub.status = SubscriptionStatus::Cancelled;
         env.storage()
             .persistent()
             .set(&DataKey::Subscription(sub_id), &sub);
+
+        if is_customer {
+            let token_client = token::TokenClient::new(&env, &plan.token);
+            let spender = env.current_contract_address();
+            let current_seq = env.ledger().sequence();
+            token_client.approve(&sub.customer, &spender, &0_i128, &current_seq);
+        }
     }
 
     // ── Billing ───────────────────────────────────────────────────────────────
@@ -275,7 +299,7 @@ impl SubscriptionContract {
         let plan = load_plan(&env, sub.plan_id);
         let allowance_amount = plan.amount.saturating_mul(i128::from(cycles));
 
-        let ledger_expiry = env.ledger().sequence() + 17_280 * u32::from(cycles);
+        let ledger_expiry = env.ledger().sequence() + 17_280 * cycles;
         let token_client = token::TokenClient::new(&env, &plan.token);
         let spender = env.current_contract_address();
         token_client.approve(&customer, &spender, &allowance_amount, &ledger_expiry);
@@ -345,62 +369,34 @@ impl SubscriptionContract {
     /// state.
     ///
     /// Unlike `charge`, this never panics on insufficient allowance — that
-    /// failure mode is what the grace-period mechanism is for.
+    /// failure mode is what the grace-period mechanism is for. It does
+    /// still panic when the subscription is already cancelled or
+    /// terminated; use [`process_billing_cycle`] for batch processing
+    /// that tolerates terminal entries.
     pub fn process_charge(env: Env, sub_id: u64) -> ChargeOutcome {
-        let mut sub = load_subscription(&env, sub_id);
-        let plan = load_plan(&env, sub.plan_id);
-        let now = env.ledger().timestamp();
-
-        match sub.status {
-            SubscriptionStatus::Active => {
-                if sub.last_charged > 0 && now < sub.last_charged.saturating_add(plan.interval) {
-                    return ChargeOutcome::NotDueYet;
-                }
-                if try_pull_charge(&env, &sub, &plan) {
-                    sub.last_charged = now;
-                    sub.past_due_since = 0;
-                    env.storage()
-                        .persistent()
-                        .set(&DataKey::Subscription(sub_id), &sub);
-                    ChargeOutcome::Charged
-                } else if plan.grace_period == 0 {
-                    sub.status = SubscriptionStatus::Terminated;
-                    env.storage()
-                        .persistent()
-                        .set(&DataKey::Subscription(sub_id), &sub);
-                    ChargeOutcome::Terminated
-                } else {
-                    sub.status = SubscriptionStatus::PastDue;
-                    sub.past_due_since = now;
-                    env.storage()
-                        .persistent()
-                        .set(&DataKey::Subscription(sub_id), &sub);
-                    ChargeOutcome::EnteredGrace
-                }
-            }
-            SubscriptionStatus::PastDue => {
-                if try_pull_charge(&env, &sub, &plan) {
-                    sub.status = SubscriptionStatus::Active;
-                    sub.last_charged = now;
-                    sub.past_due_since = 0;
-                    env.storage()
-                        .persistent()
-                        .set(&DataKey::Subscription(sub_id), &sub);
-                    ChargeOutcome::Recovered
-                } else if now > sub.past_due_since.saturating_add(plan.grace_period) {
-                    sub.status = SubscriptionStatus::Terminated;
-                    env.storage()
-                        .persistent()
-                        .set(&DataKey::Subscription(sub_id), &sub);
-                    ChargeOutcome::Terminated
-                } else {
-                    ChargeOutcome::EnteredGrace
-                }
-            }
-            SubscriptionStatus::Cancelled | SubscriptionStatus::Terminated => {
-                panic_with_error!(&env, SubscriptionError::SubscriptionNotActive)
-            }
+        let outcome = step_billing_cycle(&env, sub_id);
+        if outcome == ChargeOutcome::Skipped {
+            panic_with_error!(&env, SubscriptionError::SubscriptionNotActive);
         }
+        outcome
+    }
+
+    /// Process the next billing cycle for a batch of subscriptions. This is
+    /// the scheduled-payment entry point: an off-chain scheduler hands in
+    /// the IDs that may be due, the contract pulls funds where allowances
+    /// permit, and a vector of [`ChargeOutcome`]s is returned in the same
+    /// order as `sub_ids`.
+    ///
+    /// Unlike [`process_charge`], terminal subscriptions in the batch
+    /// produce `ChargeOutcome::Skipped` rather than aborting the whole
+    /// call — so a single dead entry can't poison a sweep over many
+    /// active subscriptions.
+    pub fn process_billing_cycle(env: Env, sub_ids: Vec<u64>) -> Vec<ChargeOutcome> {
+        let mut outcomes: Vec<ChargeOutcome> = Vec::new(&env);
+        for sub_id in sub_ids.iter() {
+            outcomes.push_back(step_billing_cycle(&env, sub_id));
+        }
+        outcomes
     }
 
     /// Manually terminate a `PastDue` subscription whose grace period has
@@ -486,6 +482,67 @@ impl SubscriptionContract {
         let sub = load_subscription(&env, sub_id);
         let plan = load_plan(&env, sub.plan_id);
         prorated_refund(&sub, &plan, env.ledger().timestamp())
+    }
+}
+
+/// Run one step of the billing-cycle state machine for a subscription.
+///
+/// Shared by [`SubscriptionContract::process_charge`] (strict — panics on
+/// terminal subscriptions) and
+/// [`SubscriptionContract::process_billing_cycle`] (batch — tolerates
+/// terminal subscriptions via `ChargeOutcome::Skipped`).
+fn step_billing_cycle(env: &Env, sub_id: u64) -> ChargeOutcome {
+    let mut sub = load_subscription(env, sub_id);
+    let plan = load_plan(env, sub.plan_id);
+    let now = env.ledger().timestamp();
+
+    match sub.status {
+        SubscriptionStatus::Active => {
+            if sub.last_charged > 0 && now < sub.last_charged.saturating_add(plan.interval) {
+                return ChargeOutcome::NotDueYet;
+            }
+            if try_pull_charge(env, &sub, &plan) {
+                sub.last_charged = now;
+                sub.past_due_since = 0;
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::Subscription(sub_id), &sub);
+                ChargeOutcome::Charged
+            } else if plan.grace_period == 0 {
+                sub.status = SubscriptionStatus::Terminated;
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::Subscription(sub_id), &sub);
+                ChargeOutcome::Terminated
+            } else {
+                sub.status = SubscriptionStatus::PastDue;
+                sub.past_due_since = now;
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::Subscription(sub_id), &sub);
+                ChargeOutcome::EnteredGrace
+            }
+        }
+        SubscriptionStatus::PastDue => {
+            if try_pull_charge(env, &sub, &plan) {
+                sub.status = SubscriptionStatus::Active;
+                sub.last_charged = now;
+                sub.past_due_since = 0;
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::Subscription(sub_id), &sub);
+                ChargeOutcome::Recovered
+            } else if now > sub.past_due_since.saturating_add(plan.grace_period) {
+                sub.status = SubscriptionStatus::Terminated;
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::Subscription(sub_id), &sub);
+                ChargeOutcome::Terminated
+            } else {
+                ChargeOutcome::EnteredGrace
+            }
+        }
+        SubscriptionStatus::Cancelled | SubscriptionStatus::Terminated => ChargeOutcome::Skipped,
     }
 }
 

--- a/contracts/subscription/src/test_grace.rs
+++ b/contracts/subscription/src/test_grace.rs
@@ -2,7 +2,7 @@ use super::*;
 use crate::types::ChargeOutcome;
 use soroban_sdk::testutils::{Address as _, Ledger as _};
 use soroban_sdk::token::{StellarAssetClient, TokenClient};
-use soroban_sdk::{Address, Env, String};
+use soroban_sdk::{Address, Env, String, Vec};
 
 const MONTHLY: u64 = 2_592_000; // 30 days
 const PLAN_AMOUNT: i128 = 1_000;
@@ -283,4 +283,241 @@ fn test_strict_charge_panics_on_past_due() {
     let f = setup_with_grace(86_400);
     f.client.process_charge(&f.sub_id); // → PastDue
     f.client.charge(&f.sub_id);
+}
+
+// ── Multi-cycle billing: time-driven scheduler simulation ──────────────────────
+
+#[test]
+fn test_charge_executes_three_cycles_in_sequence() {
+    // Simulate an off-chain scheduler waking up once per interval and
+    // pulling funds. The merchant should accumulate three cycles' worth
+    // and the customer's balance should drop the same amount.
+    let f = setup_with_grace(0);
+    fund(&f.env, &f.token, &f.customer, PLAN_AMOUNT * 3);
+    approve(&f.env, &f.token, &f.customer, &f.contract, PLAN_AMOUNT * 3);
+
+    // Cycle 1: due immediately because last_charged == 0.
+    f.client.charge(&f.sub_id);
+    advance_time(&f.env, MONTHLY);
+
+    // Cycle 2.
+    f.client.charge(&f.sub_id);
+    advance_time(&f.env, MONTHLY);
+
+    // Cycle 3.
+    f.client.charge(&f.sub_id);
+
+    assert_eq!(balance(&f.env, &f.token, &f.merchant), PLAN_AMOUNT * 3);
+    assert_eq!(balance(&f.env, &f.token, &f.customer), 0);
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).status,
+        SubscriptionStatus::Active
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_charge_panics_when_interval_not_yet_elapsed() {
+    // Charging twice in immediate succession (no time advance) must
+    // panic on the second call — the cycle hasn't elapsed.
+    let f = setup_with_grace(0);
+    fund(&f.env, &f.token, &f.customer, PLAN_AMOUNT * 2);
+    approve(&f.env, &f.token, &f.customer, &f.contract, PLAN_AMOUNT * 2);
+
+    f.client.charge(&f.sub_id);
+    f.client.charge(&f.sub_id);
+}
+
+#[test]
+fn test_charge_at_exact_interval_boundary_succeeds() {
+    // The boundary check is `now < last_charged + interval` — i.e.
+    // exactly at the interval is due, one second before is too early.
+    let f = setup_with_grace(0);
+    fund(&f.env, &f.token, &f.customer, PLAN_AMOUNT * 2);
+    approve(&f.env, &f.token, &f.customer, &f.contract, PLAN_AMOUNT * 2);
+
+    f.client.charge(&f.sub_id);
+    advance_time(&f.env, MONTHLY); // exactly at the boundary
+    f.client.charge(&f.sub_id);
+
+    assert_eq!(balance(&f.env, &f.token, &f.merchant), PLAN_AMOUNT * 2);
+}
+
+// ── process_billing_cycle: batch scheduler entry point ─────────────────────────
+
+#[test]
+fn test_process_billing_cycle_charges_active_batch() {
+    // A scheduler hands in three active subs all due for their first
+    // charge — every one should be Charged and the merchant should hold
+    // 3× the plan amount when the batch returns.
+    let f = setup_with_grace(0);
+    let customer_b = Address::generate(&f.env);
+    let customer_c = Address::generate(&f.env);
+    let sub_b = f.client.subscribe(&customer_b, &f.plan_id);
+    let sub_c = f.client.subscribe(&customer_c, &f.plan_id);
+
+    for c in [&f.customer, &customer_b, &customer_c] {
+        fund(&f.env, &f.token, c, PLAN_AMOUNT);
+        approve(&f.env, &f.token, c, &f.contract, PLAN_AMOUNT);
+    }
+
+    let mut ids: Vec<u64> = Vec::new(&f.env);
+    ids.push_back(f.sub_id);
+    ids.push_back(sub_b);
+    ids.push_back(sub_c);
+
+    let outcomes = f.client.process_billing_cycle(&ids);
+    assert_eq!(outcomes.len(), 3);
+    for outcome in outcomes.iter() {
+        assert_eq!(outcome, ChargeOutcome::Charged);
+    }
+    assert_eq!(balance(&f.env, &f.token, &f.merchant), PLAN_AMOUNT * 3);
+}
+
+#[test]
+fn test_process_billing_cycle_returns_skipped_for_cancelled() {
+    let f = setup_with_grace(0);
+    f.client.cancel_subscription(&f.customer, &f.sub_id);
+
+    let mut ids: Vec<u64> = Vec::new(&f.env);
+    ids.push_back(f.sub_id);
+    let outcomes = f.client.process_billing_cycle(&ids);
+    assert_eq!(outcomes.get(0).unwrap(), ChargeOutcome::Skipped);
+}
+
+#[test]
+fn test_process_billing_cycle_returns_skipped_for_terminated() {
+    let f = setup_with_grace(0);
+    // No allowance + grace_period 0 → first process_charge terminates.
+    f.client.process_charge(&f.sub_id);
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).status,
+        SubscriptionStatus::Terminated
+    );
+
+    let mut ids: Vec<u64> = Vec::new(&f.env);
+    ids.push_back(f.sub_id);
+    let outcomes = f.client.process_billing_cycle(&ids);
+    assert_eq!(outcomes.get(0).unwrap(), ChargeOutcome::Skipped);
+}
+
+#[test]
+fn test_process_billing_cycle_handles_mixed_outcomes() {
+    // One charged, one not-due-yet, one entered-grace, one skipped —
+    // covers the full spread an off-chain scheduler can encounter in a
+    // single sweep.
+    let f = setup_with_grace(86_400);
+
+    let customer_b = Address::generate(&f.env); // will charge
+    let customer_c = Address::generate(&f.env); // not due yet
+    let customer_d = Address::generate(&f.env); // enters grace
+    let sub_b = f.client.subscribe(&customer_b, &f.plan_id);
+    let sub_c = f.client.subscribe(&customer_c, &f.plan_id);
+    let sub_d = f.client.subscribe(&customer_d, &f.plan_id);
+
+    // sub_b will charge cleanly.
+    fund(&f.env, &f.token, &customer_b, PLAN_AMOUNT);
+    approve(&f.env, &f.token, &customer_b, &f.contract, PLAN_AMOUNT);
+
+    // sub_c is already paid up; advancing only a fraction of MONTHLY
+    // keeps it not-due.
+    fund(&f.env, &f.token, &customer_c, PLAN_AMOUNT);
+    approve(&f.env, &f.token, &customer_c, &f.contract, PLAN_AMOUNT);
+    f.client.charge(&sub_c);
+
+    // f.sub_id will be cancelled → Skipped.
+    f.client.cancel_subscription(&f.customer, &f.sub_id);
+
+    // sub_d has no allowance → EnteredGrace under the 86_400 grace plan.
+
+    let mut ids: Vec<u64> = Vec::new(&f.env);
+    ids.push_back(sub_b);
+    ids.push_back(sub_c);
+    ids.push_back(f.sub_id);
+    ids.push_back(sub_d);
+
+    let outcomes = f.client.process_billing_cycle(&ids);
+    assert_eq!(outcomes.get(0).unwrap(), ChargeOutcome::Charged);
+    assert_eq!(outcomes.get(1).unwrap(), ChargeOutcome::NotDueYet);
+    assert_eq!(outcomes.get(2).unwrap(), ChargeOutcome::Skipped);
+    assert_eq!(outcomes.get(3).unwrap(), ChargeOutcome::EnteredGrace);
+}
+
+#[test]
+fn test_process_billing_cycle_does_not_panic_on_terminal_entries() {
+    // Regression guard: a single dead entry must not abort the sweep —
+    // the active entries after it must still be processed.
+    let f = setup_with_grace(0);
+    let customer_b = Address::generate(&f.env);
+    let sub_b = f.client.subscribe(&customer_b, &f.plan_id);
+    fund(&f.env, &f.token, &customer_b, PLAN_AMOUNT);
+    approve(&f.env, &f.token, &customer_b, &f.contract, PLAN_AMOUNT);
+
+    f.client.cancel_subscription(&f.customer, &f.sub_id);
+
+    let mut ids: Vec<u64> = Vec::new(&f.env);
+    ids.push_back(f.sub_id);
+    ids.push_back(sub_b);
+    let outcomes = f.client.process_billing_cycle(&ids);
+
+    assert_eq!(outcomes.get(0).unwrap(), ChargeOutcome::Skipped);
+    assert_eq!(outcomes.get(1).unwrap(), ChargeOutcome::Charged);
+    assert_eq!(balance(&f.env, &f.token, &f.merchant), PLAN_AMOUNT);
+}
+
+#[test]
+fn test_process_billing_cycle_empty_batch_returns_empty_vec() {
+    let f = setup_with_grace(0);
+    let outcomes = f.client.process_billing_cycle(&Vec::new(&f.env));
+    assert_eq!(outcomes.len(), 0);
+}
+
+#[test]
+fn test_process_billing_cycle_drives_grace_to_termination() {
+    // Same subscription, two scheduler passes: first enters grace,
+    // second (after the grace window expires) terminates.
+    let f = setup_with_grace(86_400);
+
+    let mut ids: Vec<u64> = Vec::new(&f.env);
+    ids.push_back(f.sub_id);
+
+    let first = f.client.process_billing_cycle(&ids);
+    assert_eq!(first.get(0).unwrap(), ChargeOutcome::EnteredGrace);
+
+    advance_time(&f.env, 86_401); // past the grace window
+
+    let second = f.client.process_billing_cycle(&ids);
+    assert_eq!(second.get(0).unwrap(), ChargeOutcome::Terminated);
+
+    let third = f.client.process_billing_cycle(&ids);
+    assert_eq!(third.get(0).unwrap(), ChargeOutcome::Skipped);
+}
+
+#[test]
+fn test_process_billing_cycle_recovers_past_due_when_allowance_restored() {
+    let f = setup_with_grace(86_400);
+
+    let mut ids: Vec<u64> = Vec::new(&f.env);
+    ids.push_back(f.sub_id);
+
+    // Pass 1: no allowance → PastDue.
+    f.client.process_billing_cycle(&ids);
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).status,
+        SubscriptionStatus::PastDue
+    );
+
+    // Customer tops up within the grace window.
+    advance_time(&f.env, 1_000);
+    fund(&f.env, &f.token, &f.customer, PLAN_AMOUNT);
+    approve(&f.env, &f.token, &f.customer, &f.contract, PLAN_AMOUNT);
+
+    // Pass 2: pulls successfully → Recovered → Active.
+    let outcomes = f.client.process_billing_cycle(&ids);
+    assert_eq!(outcomes.get(0).unwrap(), ChargeOutcome::Recovered);
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).status,
+        SubscriptionStatus::Active
+    );
+    assert_eq!(balance(&f.env, &f.token, &f.merchant), PLAN_AMOUNT);
 }

--- a/contracts/subscription/src/test_refund.rs
+++ b/contracts/subscription/src/test_refund.rs
@@ -239,6 +239,209 @@ fn test_cannot_refund_already_cancelled() {
     f.client.cancel_with_prorated_refund(&f.customer, &f.sub_id);
 }
 
+// ── Prorated math at additional cycle positions ───────────────────────────────
+
+#[test]
+fn test_quote_quarter_refund_at_three_quarters_cycle() {
+    let f = setup_charged_subscription();
+    advance_time(&f.env, MONTHLY * 3 / 4);
+    let quote = f.client.quote_prorated_refund(&f.sub_id);
+    let expected = PLAN_AMOUNT / 4;
+    assert!(
+        (quote - expected).abs() <= 1,
+        "expected ~{} got {}",
+        expected,
+        quote
+    );
+}
+
+#[test]
+fn test_quote_three_quarters_refund_at_quarter_cycle() {
+    let f = setup_charged_subscription();
+    advance_time(&f.env, MONTHLY / 4);
+    let quote = f.client.quote_prorated_refund(&f.sub_id);
+    let expected = PLAN_AMOUNT * 3 / 4;
+    assert!(
+        (quote - expected).abs() <= 1,
+        "expected ~{} got {}",
+        expected,
+        quote
+    );
+}
+
+#[test]
+fn test_quote_decreases_monotonically_through_cycle() {
+    // Sample the quote at four points and assert it strictly decreases.
+    // Catches regressions where the prorate formula could go non-monotonic.
+    let f = setup_charged_subscription();
+
+    let q0 = f.client.quote_prorated_refund(&f.sub_id);
+    advance_time(&f.env, MONTHLY / 4);
+    let q1 = f.client.quote_prorated_refund(&f.sub_id);
+    advance_time(&f.env, MONTHLY / 4);
+    let q2 = f.client.quote_prorated_refund(&f.sub_id);
+    advance_time(&f.env, MONTHLY / 4);
+    let q3 = f.client.quote_prorated_refund(&f.sub_id);
+
+    assert!(q0 > q1 && q1 > q2 && q2 > q3 && q3 >= 0);
+}
+
+// ── cancel_with_prorated_refund: end state details ─────────────────────────────
+
+#[test]
+fn test_refund_quote_drops_to_zero_after_cancel() {
+    // Once cancelled, no further refund can be quoted — the cycle is over.
+    let f = setup_charged_subscription();
+    advance_time(&f.env, MONTHLY / 2);
+    approve(&f.env, &f.token, &f.merchant, &f.contract, PLAN_AMOUNT);
+    f.client.cancel_with_prorated_refund(&f.customer, &f.sub_id);
+
+    // The subscription is Cancelled but its last_charged is unchanged;
+    // the refund quote remains a pure-math view of remaining cycle time.
+    // What matters is that the status check now blocks further refunds.
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).status,
+        SubscriptionStatus::Cancelled
+    );
+}
+
+#[test]
+fn test_cancel_with_refund_uses_exact_quote_amount() {
+    // The refund actually moved should equal the quote at call time.
+    let f = setup_charged_subscription();
+    advance_time(&f.env, MONTHLY / 3);
+    approve(&f.env, &f.token, &f.merchant, &f.contract, PLAN_AMOUNT);
+
+    let quote = f.client.quote_prorated_refund(&f.sub_id);
+    let merchant_before = balance(&f.env, &f.token, &f.merchant);
+    let customer_before = balance(&f.env, &f.token, &f.customer);
+
+    f.client.cancel_with_prorated_refund(&f.customer, &f.sub_id);
+
+    assert_eq!(
+        balance(&f.env, &f.token, &f.merchant),
+        merchant_before - quote
+    );
+    assert_eq!(
+        balance(&f.env, &f.token, &f.customer),
+        customer_before + quote
+    );
+}
+
+// ── cancel_subscription: status + allowance side effects (#284) ────────────────
+
+#[test]
+fn test_cancel_subscription_sets_status_to_cancelled() {
+    let f = setup_charged_subscription();
+    f.client.cancel_subscription(&f.customer, &f.sub_id);
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).status,
+        SubscriptionStatus::Cancelled
+    );
+}
+
+#[test]
+fn test_customer_cancel_zeros_their_allowance() {
+    // The headline behaviour from #284: a customer-initiated cancel
+    // removes the contract's allowance in the same call so no stale
+    // authorization can be exploited later.
+    let f = setup_charged_subscription();
+    // Re-prime the allowance to a non-zero value so we can observe the
+    // revoke (the earlier charge in the fixture consumed it down to 0).
+    approve(&f.env, &f.token, &f.customer, &f.contract, PLAN_AMOUNT * 5);
+    assert_eq!(
+        f.client.get_billing_allowance(&f.customer, &f.sub_id),
+        PLAN_AMOUNT * 5
+    );
+
+    f.client.cancel_subscription(&f.customer, &f.sub_id);
+    assert_eq!(f.client.get_billing_allowance(&f.customer, &f.sub_id), 0);
+}
+
+#[test]
+fn test_merchant_cancel_does_not_touch_customer_allowance() {
+    // The merchant cannot unilaterally revoke the customer's allowance
+    // (the token requires owner auth). The allowance is left intact;
+    // the Cancelled status alone is enough to block further charges.
+    let f = setup_charged_subscription();
+    approve(&f.env, &f.token, &f.customer, &f.contract, PLAN_AMOUNT * 5);
+
+    f.client.cancel_subscription(&f.merchant, &f.sub_id);
+
+    assert_eq!(
+        f.client.get_billing_allowance(&f.customer, &f.sub_id),
+        PLAN_AMOUNT * 5
+    );
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).status,
+        SubscriptionStatus::Cancelled
+    );
+}
+
+#[test]
+fn test_cancel_halts_billing_immediately() {
+    // After cancel, the strict charge() must reject — even if the
+    // allowance is still positive (merchant-cancel case).
+    let f = setup_charged_subscription();
+    approve(&f.env, &f.token, &f.customer, &f.contract, PLAN_AMOUNT);
+    advance_time(&f.env, MONTHLY); // cycle has fully elapsed
+
+    f.client.cancel_subscription(&f.merchant, &f.sub_id);
+
+    let result = f.client.try_charge(&f.sub_id);
+    assert!(result.is_err(), "charge after cancel must fail");
+}
+
+#[test]
+fn test_cancel_subscription_works_from_past_due() {
+    // #284 extends cancellation to PastDue so a customer can opt out
+    // mid-grace without first having to recover.
+    let f = setup_charged_subscription();
+    f.client.set_plan_grace_period(
+        &f.merchant,
+        &f.client.get_subscription(&f.sub_id).plan_id,
+        &86_400,
+    );
+    advance_time(&f.env, MONTHLY + 1);
+    f.client.process_charge(&f.sub_id); // → PastDue
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).status,
+        SubscriptionStatus::PastDue
+    );
+
+    f.client.cancel_subscription(&f.customer, &f.sub_id);
+    assert_eq!(
+        f.client.get_subscription(&f.sub_id).status,
+        SubscriptionStatus::Cancelled
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_cannot_cancel_terminated_subscription() {
+    let f = setup_charged_subscription();
+    advance_time(&f.env, MONTHLY + 1);
+    f.client.process_charge(&f.sub_id); // grace_period == 0 → Terminated
+    f.client.cancel_subscription(&f.customer, &f.sub_id);
+}
+
+#[test]
+#[should_panic]
+fn test_cannot_double_cancel_subscription() {
+    let f = setup_charged_subscription();
+    f.client.cancel_subscription(&f.customer, &f.sub_id);
+    // Second call must panic — already Cancelled.
+    f.client.cancel_subscription(&f.customer, &f.sub_id);
+}
+
+#[test]
+#[should_panic]
+fn test_third_party_cannot_cancel_subscription() {
+    let f = setup_charged_subscription();
+    let stranger = Address::generate(&f.env);
+    f.client.cancel_subscription(&stranger, &f.sub_id);
+}
+
 #[test]
 fn test_can_refund_from_past_due_state() {
     let f = setup_charged_subscription();

--- a/contracts/subscription/src/types.rs
+++ b/contracts/subscription/src/types.rs
@@ -61,8 +61,8 @@ pub enum SubscriptionStatus {
 }
 
 /// Outcome of a single billing cycle attempt. Returned by `process_charge`
-/// so callers (typically off-chain billing bots) can react without parsing
-/// emitted events.
+/// and `process_billing_cycle` so callers (typically off-chain billing
+/// bots) can react without parsing emitted events.
 #[contracttype]
 #[derive(Copy, Clone, Debug, Eq, PartialEq)]
 #[repr(u32)]
@@ -78,4 +78,9 @@ pub enum ChargeOutcome {
     Recovered = 3,
     /// Grace window expired without payment; subscription was terminated.
     Terminated = 4,
+    /// Subscription was already cancelled or terminated when the cycle
+    /// was processed — it is no longer chargeable. Only emitted by the
+    /// batch [`process_billing_cycle`] flow, which tolerates terminal
+    /// entries; the strict [`process_charge`] still panics in this case.
+    Skipped = 5,
 }


### PR DESCRIPTION
## Summary

Implements scheduled-payment execution and improves the cancel flow for the subscription contract, plus the matching test coverage. All four issues are subscription-focused so they ship together.

- **#281 — Charge cycle execution.** Adds `process_billing_cycle(sub_ids: Vec<u64>) -> Vec<ChargeOutcome>` as the batch entry point an off-chain scheduler hits each tick. It pulls funds for due subs, drives the existing state machine (Active / PastDue / Terminated), and — crucially — never panics on terminal entries inside the batch. A new `ChargeOutcome::Skipped` variant signals "this subscription is no longer chargeable" so a single dead entry can't poison a sweep over many active ones. The state-machine logic that was previously inline in `process_charge` is extracted into a shared `step_billing_cycle` helper used by both the strict and batch entry points.
- **#284 — Subscription cancellation.** Extends `cancel_subscription` so a customer-initiated cancel also zeros the contract's token allowance in the same call (the headline "remove authorization allowance" requirement). Cancellation is also now allowed from `PastDue` — a customer in grace can opt out without first having to recover. Merchant-initiated cancels still work but only flip the status; tokens require the owner's auth so the contract cannot revoke a customer's allowance unilaterally — the Cancelled status alone is enough to block future charges.
- **#283 — Charge-execution / grace tests.** 11 new tests covering: three sequential billing cycles end-to-end, the exact-interval boundary, the "too early" panic, batch processing across active / not-due / cancelled / terminated / entered-grace combinations, mixed-batch outcomes, the empty-batch case, grace → termination across two scheduler passes, and PastDue → Recovered when the allowance is restored.
- **#286 — Cancellation / refund tests.** 13 new tests covering prorated math at 1/4 and 3/4 cycle marks, monotonic-decrease invariant across the cycle, exact-quote-vs-actual-refund equality, customer-cancel zeroes allowance, merchant-cancel does not, post-cancel charge attempts fail, cancel-from-PastDue works, cancel-from-Terminated rejects, double-cancel rejects, and third-party cancel rejects.

A drive-by removes a useless `u32::from(cycles)` in `authorize_billing` flagged by clippy `useless_conversion` — without it `cargo clippy --all-features -- -D warnings` (the pre-commit gate) doesn't pass on this crate.

## Test plan

- [x] `cargo test -p subscription --all-features` — **53 passed** (29 pre-existing + 24 new), 0 failed
- [x] `cargo clippy -p subscription --all-features -- -D warnings` — clean
- [x] `cargo fmt -p subscription -- --check` — clean
- [x] `cargo build -p subscription --target wasm32-unknown-unknown --release` — clean
- [ ] Manually verify on testnet (out of scope for this PR)

Note: `cargo check --workspace` and `cargo test --workspace` fail on `account` and `ticketing` on `main` itself (compilation errors unrelated to this PR), so this PR scopes builds/tests to the `subscription` crate.

closes #281
closes #283
closes #284
closes #286