### PR TITLE
feat(subscription): implement creator fee routing, renewal/expiry events, upgrades/downgrades and trial periods

### DIFF
--- a/contracts/subscription/src/lib.rs
+++ b/contracts/subscription/src/lib.rs
@@ -5,6 +5,8 @@ mod errors;
 mod test_grace;
 #[cfg(test)]
 mod test_refund;
+#[cfg(test)]
+mod test_upgrades_downgrades;
 mod types;
 
 use errors::SubscriptionError;
@@ -97,6 +99,8 @@ impl SubscriptionContract {
         token: Address,
         amount: i128,
         interval: u64,
+        creator: Option<Address>,
+        trial_period: u64,
     ) -> u64 {
         merchant.require_auth();
 
@@ -131,6 +135,8 @@ impl SubscriptionContract {
             active: true,
             created_at: env.ledger().timestamp(),
             grace_period: 0,
+            creator,
+            trial_period,
         };
         env.storage()
             .persistent()
@@ -232,6 +238,7 @@ impl SubscriptionContract {
             created_at: env.ledger().timestamp(),
             last_charged: 0,
             past_due_since: 0,
+            pending_downgrade_plan_id: 0,
         };
         env.storage()
             .persistent()
@@ -281,6 +288,14 @@ impl SubscriptionContract {
             let current_seq = env.ledger().sequence();
             token_client.approve(&sub.customer, &spender, &0_i128, &current_seq);
         }
+
+        // Emit SubExpired
+        types::SubExpired {
+            subscription_id: sub.id,
+            plan_id: sub.plan_id,
+            customer: sub.customer.clone(),
+            timestamp: env.ledger().timestamp(),
+        }.publish(&env);
     }
 
     // ── Billing ───────────────────────────────────────────────────────────────
@@ -338,10 +353,20 @@ impl SubscriptionContract {
         if sub.status != SubscriptionStatus::Active {
             panic_with_error!(&env, SubscriptionError::SubscriptionNotActive);
         }
-        let plan = load_plan(&env, sub.plan_id);
+        let mut plan = load_plan(&env, sub.plan_id);
         let now = env.ledger().timestamp();
-        if sub.last_charged > 0 && now < sub.last_charged.saturating_add(plan.interval) {
+        if sub.last_charged > 0 {
+            if now < sub.last_charged.saturating_add(plan.interval) {
+                panic_with_error!(&env, SubscriptionError::ChargeTooEarly);
+            }
+        } else if now < sub.created_at.saturating_add(plan.trial_period) {
             panic_with_error!(&env, SubscriptionError::ChargeTooEarly);
+        }
+
+        if sub.pending_downgrade_plan_id != 0 {
+            sub.plan_id = sub.pending_downgrade_plan_id;
+            sub.pending_downgrade_plan_id = 0;
+            plan = load_plan(&env, sub.plan_id);
         }
 
         let token_client = token::TokenClient::new(&env, &plan.token);
@@ -352,13 +377,22 @@ impl SubscriptionContract {
             panic_with_error!(&env, SubscriptionError::InsufficientAllowance);
         }
 
-        token_client.transfer_from(&spender, &sub.customer, &plan.merchant, &plan.amount);
+        let recipient = plan.creator.as_ref().unwrap_or(&plan.merchant);
+        token_client.transfer_from(&spender, &sub.customer, recipient, &plan.amount);
 
         sub.last_charged = now;
         sub.past_due_since = 0;
         env.storage()
             .persistent()
             .set(&DataKey::Subscription(sub_id), &sub);
+
+        // Emit SubRenewed
+        types::SubRenewed {
+            subscription_id: sub.id,
+            plan_id: sub.plan_id,
+            customer: sub.customer.clone(),
+            timestamp: now,
+        }.publish(&env);
     }
 
     /// Forgiving variant of [`charge`]. Drives the subscription's billing
@@ -419,6 +453,14 @@ impl SubscriptionContract {
         env.storage()
             .persistent()
             .set(&DataKey::Subscription(sub_id), &sub);
+
+        // Emit SubExpired
+        types::SubExpired {
+            subscription_id: sub.id,
+            plan_id: sub.plan_id,
+            customer: sub.customer.clone(),
+            timestamp: now,
+        }.publish(&env);
     }
 
     /// Cancel a subscription and refund the unused portion of the current
@@ -443,15 +485,17 @@ impl SubscriptionContract {
             panic_with_error!(&env, SubscriptionError::SubscriptionNotActive);
         }
         let plan = load_plan(&env, sub.plan_id);
+        let source = plan.creator.as_ref().unwrap_or(&plan.merchant);
         let is_customer = sub.customer == caller;
         let is_merchant = plan.merchant == caller;
-        if !is_customer && !is_merchant {
+        let is_creator = plan.creator.as_ref().map_or(false, |c| c == &caller);
+        if !is_customer && !is_merchant && !is_creator {
             panic_with_error!(&env, SubscriptionError::NotAuthorized);
         }
         // Whichever party did not initiate must still authorize so refunds
         // require mutual consent.
         if is_customer {
-            plan.merchant.require_auth();
+            source.require_auth();
         } else {
             sub.customer.require_auth();
         }
@@ -461,18 +505,23 @@ impl SubscriptionContract {
             panic_with_error!(&env, SubscriptionError::NothingToRefund);
         }
 
-        // Pull the refund from the merchant's balance into the customer's.
-        // The merchant's earlier `approve(contract, ...)` is what makes this
-        // possible — without it the transfer fails and the subscription is
-        // left untouched.
+        // Pull the refund from the merchant's/creator's balance into the customer's.
         let token_client = token::TokenClient::new(&env, &plan.token);
         let spender = env.current_contract_address();
-        token_client.transfer_from(&spender, &plan.merchant, &sub.customer, &refund_amount);
+        token_client.transfer_from(&spender, source, &sub.customer, &refund_amount);
 
         sub.status = SubscriptionStatus::Cancelled;
         env.storage()
             .persistent()
             .set(&DataKey::Subscription(sub_id), &sub);
+
+        // Emit SubExpired
+        types::SubExpired {
+            subscription_id: sub.id,
+            plan_id: sub.plan_id,
+            customer: sub.customer.clone(),
+            timestamp: env.ledger().timestamp(),
+        }.publish(&env);
     }
 
     /// Read-only helper: how much would be refunded if the subscription
@@ -482,6 +531,86 @@ impl SubscriptionContract {
         let sub = load_subscription(&env, sub_id);
         let plan = load_plan(&env, sub.plan_id);
         prorated_refund(&sub, &plan, env.ledger().timestamp())
+    }
+
+    /// Upgrade a subscription immediately.
+    /// Deducts (new_plan.amount - prorated_refund_of_old_plan) from customer and resets billing cycle.
+    pub fn upgrade_subscription(env: Env, customer: Address, sub_id: u64, new_plan_id: u64) {
+        customer.require_auth();
+        let mut sub = load_subscription(&env, sub_id);
+        if sub.customer != customer {
+            panic_with_error!(&env, SubscriptionError::NotAuthorized);
+        }
+        if sub.status != SubscriptionStatus::Active {
+            panic_with_error!(&env, SubscriptionError::SubscriptionNotActive);
+        }
+        let old_plan = load_plan(&env, sub.plan_id);
+        let new_plan = load_plan(&env, new_plan_id);
+        if !new_plan.active {
+            panic_with_error!(&env, SubscriptionError::PlanNotActive);
+        }
+        if old_plan.token != new_plan.token {
+            panic_with_error!(&env, SubscriptionError::TokenNotAccepted);
+        }
+
+        let now = env.ledger().timestamp();
+        let refund = prorated_refund(&sub, &old_plan, now);
+        let mut upgrade_cost = new_plan.amount.saturating_sub(refund);
+        if upgrade_cost < 0 {
+            upgrade_cost = 0;
+        }
+
+        let token_client = token::TokenClient::new(&env, &new_plan.token);
+        let spender = env.current_contract_address();
+
+        if upgrade_cost > 0 {
+            let allowance = token_client.allowance(&sub.customer, &spender);
+            if allowance < upgrade_cost {
+                panic_with_error!(&env, SubscriptionError::InsufficientAllowance);
+            }
+            let recipient = new_plan.creator.as_ref().unwrap_or(&new_plan.merchant);
+            token_client.transfer_from(&spender, &sub.customer, recipient, &upgrade_cost);
+        }
+
+        sub.plan_id = new_plan_id;
+        sub.last_charged = now;
+        sub.pending_downgrade_plan_id = 0;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(sub_id), &sub);
+
+        // Emit SubRenewed
+        types::SubRenewed {
+            subscription_id: sub.id,
+            plan_id: sub.plan_id,
+            customer: sub.customer.clone(),
+            timestamp: now,
+        }.publish(&env);
+    }
+
+    /// Schedule a deferred downgrade to be applied at the end of the current billing cycle.
+    pub fn downgrade_subscription(env: Env, customer: Address, sub_id: u64, new_plan_id: u64) {
+        customer.require_auth();
+        let mut sub = load_subscription(&env, sub_id);
+        if sub.customer != customer {
+            panic_with_error!(&env, SubscriptionError::NotAuthorized);
+        }
+        if sub.status != SubscriptionStatus::Active {
+            panic_with_error!(&env, SubscriptionError::SubscriptionNotActive);
+        }
+        let old_plan = load_plan(&env, sub.plan_id);
+        let new_plan = load_plan(&env, new_plan_id);
+        if !new_plan.active {
+            panic_with_error!(&env, SubscriptionError::PlanNotActive);
+        }
+        if old_plan.token != new_plan.token {
+            panic_with_error!(&env, SubscriptionError::TokenNotAccepted);
+        }
+
+        sub.pending_downgrade_plan_id = new_plan_id;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(sub_id), &sub);
     }
 }
 
@@ -493,26 +622,55 @@ impl SubscriptionContract {
 /// terminal subscriptions via `ChargeOutcome::Skipped`).
 fn step_billing_cycle(env: &Env, sub_id: u64) -> ChargeOutcome {
     let mut sub = load_subscription(env, sub_id);
-    let plan = load_plan(env, sub.plan_id);
+    let mut plan = load_plan(env, sub.plan_id);
     let now = env.ledger().timestamp();
 
     match sub.status {
         SubscriptionStatus::Active => {
-            if sub.last_charged > 0 && now < sub.last_charged.saturating_add(plan.interval) {
+            if sub.last_charged > 0 {
+                if now < sub.last_charged.saturating_add(plan.interval) {
+                    return ChargeOutcome::NotDueYet;
+                }
+            } else if now < sub.created_at.saturating_add(plan.trial_period) {
                 return ChargeOutcome::NotDueYet;
             }
+
+            if sub.pending_downgrade_plan_id != 0 {
+                sub.plan_id = sub.pending_downgrade_plan_id;
+                sub.pending_downgrade_plan_id = 0;
+                plan = load_plan(env, sub.plan_id);
+            }
+
             if try_pull_charge(env, &sub, &plan) {
                 sub.last_charged = now;
                 sub.past_due_since = 0;
                 env.storage()
                     .persistent()
                     .set(&DataKey::Subscription(sub_id), &sub);
+
+                // Emit SubRenewed
+                types::SubRenewed {
+                    subscription_id: sub.id,
+                    plan_id: sub.plan_id,
+                    customer: sub.customer.clone(),
+                    timestamp: now,
+                }.publish(env);
+
                 ChargeOutcome::Charged
             } else if plan.grace_period == 0 {
                 sub.status = SubscriptionStatus::Terminated;
                 env.storage()
                     .persistent()
                     .set(&DataKey::Subscription(sub_id), &sub);
+
+                // Emit SubExpired
+                types::SubExpired {
+                    subscription_id: sub.id,
+                    plan_id: sub.plan_id,
+                    customer: sub.customer.clone(),
+                    timestamp: now,
+                }.publish(env);
+
                 ChargeOutcome::Terminated
             } else {
                 sub.status = SubscriptionStatus::PastDue;
@@ -524,6 +682,12 @@ fn step_billing_cycle(env: &Env, sub_id: u64) -> ChargeOutcome {
             }
         }
         SubscriptionStatus::PastDue => {
+            if sub.pending_downgrade_plan_id != 0 {
+                sub.plan_id = sub.pending_downgrade_plan_id;
+                sub.pending_downgrade_plan_id = 0;
+                plan = load_plan(env, sub.plan_id);
+            }
+
             if try_pull_charge(env, &sub, &plan) {
                 sub.status = SubscriptionStatus::Active;
                 sub.last_charged = now;
@@ -531,12 +695,30 @@ fn step_billing_cycle(env: &Env, sub_id: u64) -> ChargeOutcome {
                 env.storage()
                     .persistent()
                     .set(&DataKey::Subscription(sub_id), &sub);
+
+                // Emit SubRenewed
+                types::SubRenewed {
+                    subscription_id: sub.id,
+                    plan_id: sub.plan_id,
+                    customer: sub.customer.clone(),
+                    timestamp: now,
+                }.publish(env);
+
                 ChargeOutcome::Recovered
             } else if now > sub.past_due_since.saturating_add(plan.grace_period) {
                 sub.status = SubscriptionStatus::Terminated;
                 env.storage()
                     .persistent()
                     .set(&DataKey::Subscription(sub_id), &sub);
+
+                // Emit SubExpired
+                types::SubExpired {
+                    subscription_id: sub.id,
+                    plan_id: sub.plan_id,
+                    customer: sub.customer.clone(),
+                    timestamp: now,
+                }.publish(env);
+
                 ChargeOutcome::Terminated
             } else {
                 ChargeOutcome::EnteredGrace
@@ -556,7 +738,8 @@ fn try_pull_charge(env: &Env, sub: &Subscription, plan: &Plan) -> bool {
     if allowance < plan.amount {
         return false;
     }
-    token_client.transfer_from(&spender, &sub.customer, &plan.merchant, &plan.amount);
+    let recipient = plan.creator.as_ref().unwrap_or(&plan.merchant);
+    token_client.transfer_from(&spender, &sub.customer, recipient, &plan.amount);
     true
 }
 

--- a/contracts/subscription/src/test_grace.rs
+++ b/contracts/subscription/src/test_grace.rs
@@ -60,6 +60,8 @@ fn setup_with_grace(grace_period: u64) -> Fixture<'static> {
         &token,
         &PLAN_AMOUNT,
         &MONTHLY,
+        &None,
+        &0,
     );
     if grace_period > 0 {
         client.set_plan_grace_period(&merchant, &plan_id, &grace_period);

--- a/contracts/subscription/src/test_refund.rs
+++ b/contracts/subscription/src/test_refund.rs
@@ -64,6 +64,8 @@ fn setup_charged_subscription() -> Fixture<'static> {
         &token,
         &PLAN_AMOUNT,
         &MONTHLY,
+        &None,
+        &0,
     );
     let sub_id = client.subscribe(&customer, &plan_id);
 
@@ -107,6 +109,8 @@ fn test_quote_zero_when_never_charged() {
         &token,
         &PLAN_AMOUNT,
         &MONTHLY,
+        &None,
+        &0,
     );
     let sub_id = client.subscribe(&customer, &plan_id);
 

--- a/contracts/subscription/src/test_upgrades_downgrades.rs
+++ b/contracts/subscription/src/test_upgrades_downgrades.rs
@@ -1,0 +1,300 @@
+use super::*;
+use crate::types::ChargeOutcome;
+use soroban_sdk::testutils::{Address as _, Ledger as _, Events as _};
+use soroban_sdk::token::{StellarAssetClient, TokenClient};
+use soroban_sdk::{Address, Env, String, Symbol, TryIntoVal};
+
+const MONTHLY: u64 = 2_592_000; // 30 days
+const PLAN_AMOUNT: i128 = 1_000;
+
+struct Fixture<'a> {
+    env: Env,
+    contract: Address,
+    client: SubscriptionContractClient<'a>,
+    merchant: Address,
+    customer: Address,
+    creator: Address,
+    token: Address,
+    plan_standard_id: u64,
+    plan_premium_id: u64,
+    plan_creator_id: u64,
+    plan_trial_id: u64,
+}
+
+fn fund(env: &Env, token: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+fn approve(env: &Env, token: &Address, owner: &Address, spender: &Address, amount: i128) {
+    let expiry = env.ledger().sequence() + 1_000_000;
+    TokenClient::new(env, token).approve(owner, spender, &amount, &expiry);
+}
+
+fn balance(env: &Env, token: &Address, who: &Address) -> i128 {
+    TokenClient::new(env, token).balance(who)
+}
+
+fn setup_all() -> Fixture<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+    let contract = env.register(SubscriptionContract, ());
+    let client = SubscriptionContractClient::new(&env, &contract);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    client.add_accepted_token(&token);
+
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+    let creator = Address::generate(&env);
+
+    // Plan Standard (no creator, no trial)
+    let plan_standard_id = client.create_plan(
+        &merchant,
+        &String::from_str(&env, "Standard"),
+        &token,
+        &PLAN_AMOUNT,
+        &MONTHLY,
+        &None,
+        &0,
+    );
+
+    // Plan Premium (no creator, no trial)
+    let plan_premium_id = client.create_plan(
+        &merchant,
+        &String::from_str(&env, "Premium"),
+        &token,
+        &(PLAN_AMOUNT * 3),
+        &MONTHLY,
+        &None,
+        &0,
+    );
+
+    // Plan Creator (with creator, no trial)
+    let plan_creator_id = client.create_plan(
+        &merchant,
+        &String::from_str(&env, "Creator Plan"),
+        &token,
+        &PLAN_AMOUNT,
+        &MONTHLY,
+        &Some(creator.clone()),
+        &0,
+    );
+
+    // Plan Trial (no creator, with 7-day trial)
+    let plan_trial_id = client.create_plan(
+        &merchant,
+        &String::from_str(&env, "Trial Plan"),
+        &token,
+        &PLAN_AMOUNT,
+        &MONTHLY,
+        &None,
+        &604_800, // 7 days in seconds
+    );
+
+    Fixture {
+        env,
+        contract,
+        client,
+        merchant,
+        customer,
+        creator,
+        token,
+        plan_standard_id,
+        plan_premium_id,
+        plan_creator_id,
+        plan_trial_id,
+    }
+}
+
+fn advance_time(env: &Env, seconds: u64) {
+    env.ledger().with_mut(|l| {
+        l.timestamp += seconds;
+    });
+}
+
+// ── Creator Fee Distribution Tests ─────────────────────────────────────────────
+
+#[test]
+fn test_creator_receives_direct_funds() {
+    let f = setup_all();
+    fund(&f.env, &f.token, &f.customer, 5_000);
+    approve(&f.env, &f.token, &f.customer, &f.contract, 5_000);
+
+    let sub_id = f.client.subscribe(&f.customer, &f.plan_creator_id);
+    let outcome = f.client.process_charge(&sub_id);
+
+    assert_eq!(outcome, ChargeOutcome::Charged);
+    assert_eq!(balance(&f.env, &f.token, &f.creator), PLAN_AMOUNT);
+    assert_eq!(balance(&f.env, &f.token, &f.merchant), 0);
+}
+
+#[test]
+fn test_refund_pulled_from_creator() {
+    let f = setup_all();
+    fund(&f.env, &f.token, &f.customer, 5_000);
+    approve(&f.env, &f.token, &f.customer, &f.contract, 5_000);
+
+    let sub_id = f.client.subscribe(&f.customer, &f.plan_creator_id);
+    f.client.charge(&sub_id);
+
+    // Creator funds/approves refund
+    approve(&f.env, &f.token, &f.creator, &f.contract, PLAN_AMOUNT);
+
+    let customer_before = balance(&f.env, &f.token, &f.customer);
+    let creator_before = balance(&f.env, &f.token, &f.creator);
+
+    // Cancel with refund
+    f.client.cancel_with_prorated_refund(&f.customer, &sub_id);
+
+    assert_eq!(balance(&f.env, &f.token, &f.customer), customer_before + PLAN_AMOUNT);
+    assert_eq!(balance(&f.env, &f.token, &f.creator), creator_before - PLAN_AMOUNT);
+}
+
+// ── Webhook / Event Triggers Tests ─────────────────────────────────────────────
+
+#[test]
+fn test_sub_renewed_event_emitted() {
+    let f = setup_all();
+    fund(&f.env, &f.token, &f.customer, 5_000);
+    approve(&f.env, &f.token, &f.customer, &f.contract, 5_000);
+
+    let sub_id = f.client.subscribe(&f.customer, &f.plan_standard_id);
+    f.client.charge(&sub_id);
+
+    let events = f.env.events().all();
+    assert!(!events.is_empty());
+
+    let mut found = false;
+    for event in events.iter() {
+        let (_, topics, _) = event;
+        if topics.len() > 0 {
+            let event_name: Symbol = topics.get(0).unwrap().try_into_val(&f.env).unwrap();
+            if event_name == Symbol::new(&f.env, "sub_renewed") {
+                found = true;
+                break;
+            }
+        }
+    }
+    assert!(found, "SubRenewed event was not found");
+}
+
+#[test]
+fn test_sub_expired_event_emitted_on_cancel() {
+    let f = setup_all();
+    let sub_id = f.client.subscribe(&f.customer, &f.plan_standard_id);
+    f.client.cancel_subscription(&f.customer, &sub_id);
+
+    let events = f.env.events().all();
+    assert!(!events.is_empty());
+
+    let mut found = false;
+    for event in events.iter() {
+        let (_, topics, _) = event;
+        if topics.len() > 0 {
+            let event_name: Symbol = topics.get(0).unwrap().try_into_val(&f.env).unwrap();
+            if event_name == Symbol::new(&f.env, "sub_expired") {
+                found = true;
+                break;
+            }
+        }
+    }
+    assert!(found, "SubExpired event was not found");
+}
+
+// ── Plan Upgrades & Downgrades Tests ───────────────────────────────────────────
+
+#[test]
+fn test_instant_upgrade_cost_calculation_and_execution() {
+    let f = setup_all();
+    fund(&f.env, &f.token, &f.customer, 10_000);
+    approve(&f.env, &f.token, &f.customer, &f.contract, 10_000);
+
+    let sub_id = f.client.subscribe(&f.customer, &f.plan_standard_id);
+    f.client.charge(&sub_id); // Charged standard (1_000)
+
+    // Advance 10 days out of 30. Remaining: 20 days.
+    // Prorated refund for remaining 20 days: 1_000 * 20 / 30 = 666.
+    // Premium plan costs 3_000.
+    // Net upgrade cost: 3_000 - 666 = 2_334.
+    advance_time(&f.env, 864_000); // 10 days in seconds
+
+    let customer_before = balance(&f.env, &f.token, &f.customer); // 9_000
+    let merchant_before = balance(&f.env, &f.token, &f.merchant); // 1_000
+
+    f.client.upgrade_subscription(&f.customer, &sub_id, &f.plan_premium_id);
+
+    // Premium plan is now active
+    let sub = f.client.get_subscription(&sub_id);
+    assert_eq!(sub.plan_id, f.plan_premium_id);
+    assert_eq!(sub.last_charged, f.env.ledger().timestamp());
+
+    // Balance changes
+    let customer_after = balance(&f.env, &f.token, &f.customer);
+    let merchant_after = balance(&f.env, &f.token, &f.merchant);
+
+    // Upgrade cost should be 2_334
+    assert_eq!(customer_before - customer_after, 2_334);
+    assert_eq!(merchant_after - merchant_before, 2_334);
+}
+
+#[test]
+fn test_deferred_downgrade_execution() {
+    let f = setup_all();
+    fund(&f.env, &f.token, &f.customer, 10_000);
+    approve(&f.env, &f.token, &f.customer, &f.contract, 10_000);
+
+    let sub_id = f.client.subscribe(&f.customer, &f.plan_premium_id);
+    f.client.charge(&sub_id); // Charged premium (3_000)
+
+    // Schedule downgrade to standard (1_000)
+    f.client.downgrade_subscription(&f.customer, &sub_id, &f.plan_standard_id);
+
+    // Plan should still be premium before cycle ends
+    let sub = f.client.get_subscription(&sub_id);
+    assert_eq!(sub.plan_id, f.plan_premium_id);
+
+    // Advance 30 days (end of cycle)
+    advance_time(&f.env, MONTHLY);
+
+    let merchant_before = balance(&f.env, &f.token, &f.merchant);
+    // Charge next cycle
+    f.client.charge(&sub_id);
+
+    // Verify downgraded and standard amount charged
+    let sub_after = f.client.get_subscription(&sub_id);
+    assert_eq!(sub_after.plan_id, f.plan_standard_id);
+    assert_eq!(balance(&f.env, &f.token, &f.merchant), merchant_before + PLAN_AMOUNT);
+}
+
+// ── Trial Period Tests ─────────────────────────────────────────────────────────
+
+#[test]
+fn test_trial_period_defers_pull() {
+    let f = setup_all();
+    fund(&f.env, &f.token, &f.customer, 5_000);
+    approve(&f.env, &f.token, &f.customer, &f.contract, 5_000);
+
+    let sub_id = f.client.subscribe(&f.customer, &f.plan_trial_id);
+
+    // Try to charge immediately -> fails
+    let res = f.client.try_charge(&sub_id);
+    assert!(res.is_err());
+
+    // Advance 6 days -> fails
+    advance_time(&f.env, 518_400); // 6 days
+    let res = f.client.try_charge(&sub_id);
+    assert!(res.is_err());
+
+    // Advance to 7.1 days -> succeeds
+    advance_time(&f.env, 100_000); // 7.1 days total
+    f.client.charge(&sub_id);
+    assert_eq!(balance(&f.env, &f.token, &f.merchant), PLAN_AMOUNT);
+}

--- a/contracts/subscription/src/types.rs
+++ b/contracts/subscription/src/types.rs
@@ -1,4 +1,22 @@
-use soroban_sdk::{contracttype, Address, String};
+use soroban_sdk::{contracttype, contractevent, Address, String};
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SubRenewed {
+    pub subscription_id: u64,
+    pub plan_id: u64,
+    pub customer: Address,
+    pub timestamp: u64,
+}
+
+#[contractevent]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SubExpired {
+    pub subscription_id: u64,
+    pub plan_id: u64,
+    pub customer: Address,
+    pub timestamp: u64,
+}
 
 #[contracttype]
 pub enum DataKey {
@@ -28,6 +46,8 @@ pub struct Plan {
     /// Seconds a subscription remains in `PastDue` before being terminated.
     /// `0` means no grace — a failed charge terminates immediately.
     pub grace_period: u64,
+    pub creator: Option<Address>,
+    pub trial_period: u64,
 }
 
 /// An active or cancelled subscription held by a customer.
@@ -44,6 +64,7 @@ pub struct Subscription {
     /// Timestamp at which the subscription entered `PastDue`. `0` if not
     /// currently past due. Used to enforce the plan's grace period.
     pub past_due_since: u64,
+    pub pending_downgrade_plan_id: u64,
 }
 
 #[contracttype]


### PR DESCRIPTION

### PR Description
This PR resolves all four requested subscription contract issues in the workspace.

- **Subscription Fee Distribution to Content Creators**
  - Added support for a plan-specific `creator` address. Incoming billing charges and prorated refunds are now routed directly to/from the creator if defined.
  - Closes #293

- **Webhook/Event Triggers for Subscription Renewal**
  - Implemented the `sub_renewed` and `sub_expired` contract events, emitted at billing, recovery, cancellation, and termination boundaries to support indexing.
  - Closes #296

- **Plan Upgrades and Downgrades**
  - Implemented instant upgrades (prorating the remaining time on the old tier and charging the difference immediately) and deferred downgrades (automatically scheduled and applied at the end of the current billing cycle).
  - Closes #292

- **Trial Period Implementation**
  - Added a `trial_period` duration to the plan struct that defers the first billing cycle pull until the trial period has fully elapsed.
  - Closes #294
