### PR TITLE
feat: multi-token subscriptions, integration tests, and crowdfund con…

### DIFF
--- a/contracts/crowdfund/Cargo.toml
+++ b/contracts/crowdfund/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "crowdfund"
+version = "0.0.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["lib", "cdylib"]
+doctest = false
+
+[dependencies]
+soroban-sdk = { workspace = true }
+
+[dev-dependencies]
+soroban-sdk = { workspace = true, features = ["testutils"] }

--- a/contracts/crowdfund/src/errors.rs
+++ b/contracts/crowdfund/src/errors.rs
@@ -1,0 +1,13 @@
+use soroban_sdk::contracterror;
+
+#[contracterror]
+#[derive(Copy, Clone, Debug, Eq, PartialEq)]
+#[repr(u32)]
+pub enum CrowdfundError {
+    AlreadyInitialized = 1,
+    NotInitialized = 2,
+    InvalidGoal = 3,
+    InvalidDeadline = 4,
+    InvalidAmount = 5,
+    CampaignEnded = 6,
+}

--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -1,0 +1,142 @@
+#![no_std]
+
+mod errors;
+#[cfg(test)]
+mod test;
+
+use errors::CrowdfundError;
+use soroban_sdk::{contract, contractimpl, contracttype, panic_with_error, token, Address, Env};
+
+#[contracttype]
+enum DataKey {
+    Organizer,
+    Token,
+    Goal,
+    Deadline,
+    Raised,
+}
+
+#[contract]
+pub struct CrowdfundContract;
+
+#[contractimpl]
+impl CrowdfundContract {
+    /// Initialise a campaign. Sets the funding goal (in token base units)
+    /// and the deadline (Unix timestamp after which no contributions are
+    /// accepted). Only callable once.
+    ///
+    /// # Arguments
+    /// * `organizer` – address that will receive funds if the goal is met.
+    /// * `token`     – accepted payment token.
+    /// * `goal`      – target amount in token base units (must be > 0).
+    /// * `deadline`  – Unix timestamp of the campaign end (must be in the future).
+    pub fn init_campaign(
+        env: Env,
+        organizer: Address,
+        token: Address,
+        goal: i128,
+        deadline: u64,
+    ) {
+        if env.storage().persistent().has(&DataKey::Organizer) {
+            panic_with_error!(&env, CrowdfundError::AlreadyInitialized);
+        }
+        if goal <= 0 {
+            panic_with_error!(&env, CrowdfundError::InvalidGoal);
+        }
+        if deadline <= env.ledger().timestamp() {
+            panic_with_error!(&env, CrowdfundError::InvalidDeadline);
+        }
+
+        env.storage().persistent().set(&DataKey::Organizer, &organizer);
+        env.storage().persistent().set(&DataKey::Token, &token);
+        env.storage().persistent().set(&DataKey::Goal, &goal);
+        env.storage().persistent().set(&DataKey::Deadline, &deadline);
+        env.storage().persistent().set(&DataKey::Raised, &0_i128);
+    }
+
+    /// Contribute `amount` tokens to the campaign. The caller must have
+    /// pre-approved the contract to spend at least `amount` from their
+    /// balance. Panics after the deadline or if the campaign is not yet
+    /// initialised.
+    pub fn contribute(env: Env, contributor: Address, amount: i128) {
+        contributor.require_auth();
+
+        if amount <= 0 {
+            panic_with_error!(&env, CrowdfundError::InvalidAmount);
+        }
+
+        let deadline: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Deadline)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
+
+        if env.ledger().timestamp() > deadline {
+            panic_with_error!(&env, CrowdfundError::CampaignEnded);
+        }
+
+        let token_addr: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Token)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
+
+        let contract_addr = env.current_contract_address();
+        token::TokenClient::new(&env, &token_addr)
+            .transfer(&contributor, &contract_addr, &amount);
+
+        let raised: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Raised)
+            .unwrap_or(0);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Raised, &raised.saturating_add(amount));
+    }
+
+    // ── Read-only accessors ───────────────────────────────────────────────────
+
+    pub fn goal(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Goal)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized))
+    }
+
+    pub fn deadline(env: Env) -> u64 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Deadline)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized))
+    }
+
+    pub fn raised(env: Env) -> i128 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Raised)
+            .unwrap_or(0)
+    }
+
+    pub fn organizer(env: Env) -> Address {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Organizer)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized))
+    }
+
+    /// Returns `true` when the raised amount has reached or exceeded the goal.
+    pub fn goal_reached(env: Env) -> bool {
+        let goal: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Goal)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
+        let raised: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Raised)
+            .unwrap_or(0);
+        raised >= goal
+    }
+}

--- a/contracts/crowdfund/src/test.rs
+++ b/contracts/crowdfund/src/test.rs
@@ -1,0 +1,98 @@
+use super::*;
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::token::StellarAssetClient;
+use soroban_sdk::{Address, Env};
+
+fn setup() -> (Env, Address, CrowdfundContractClient<'static>, Address, Address, Address) {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+    let contract = env.register(CrowdfundContract, ());
+    let client = CrowdfundContractClient::new(&env, &contract);
+
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    let organizer = Address::generate(&env);
+    let contributor = Address::generate(&env);
+
+    (env, contract, client, token, organizer, contributor)
+}
+
+#[test]
+fn test_init_campaign_stores_goal_and_deadline() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let goal = 10_000_i128;
+    let deadline = env.ledger().timestamp() + 86_400;
+
+    client.init_campaign(&organizer, &token, &goal, &deadline);
+
+    assert_eq!(client.goal(), goal);
+    assert_eq!(client.deadline(), deadline);
+    assert_eq!(client.raised(), 0);
+    assert_eq!(client.organizer(), organizer);
+    assert!(!client.goal_reached());
+}
+
+#[test]
+#[should_panic]
+fn test_double_init_panics() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &10_000, &deadline);
+    client.init_campaign(&organizer, &token, &10_000, &deadline);
+}
+
+#[test]
+#[should_panic]
+fn test_zero_goal_panics() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &0, &deadline);
+}
+
+#[test]
+#[should_panic]
+fn test_past_deadline_panics() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    client.init_campaign(&organizer, &token, &1_000, &(env.ledger().timestamp() - 1));
+}
+
+#[test]
+fn test_contribute_increases_raised() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &5_000, &deadline);
+
+    StellarAssetClient::new(&env, &token).mint(&contributor, &3_000);
+    client.contribute(&contributor, &3_000);
+
+    assert_eq!(client.raised(), 3_000);
+    assert!(!client.goal_reached());
+}
+
+#[test]
+fn test_goal_reached_when_fully_funded() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+
+    StellarAssetClient::new(&env, &token).mint(&contributor, &1_000);
+    client.contribute(&contributor, &1_000);
+
+    assert!(client.goal_reached());
+}
+
+#[test]
+#[should_panic]
+fn test_contribute_after_deadline_panics() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 100;
+    client.init_campaign(&organizer, &token, &5_000, &deadline);
+
+    env.ledger().with_mut(|l| l.timestamp += 200);
+    StellarAssetClient::new(&env, &token).mint(&contributor, &1_000);
+    client.contribute(&contributor, &1_000);
+}

--- a/contracts/subscription/src/lib.rs
+++ b/contracts/subscription/src/lib.rs
@@ -4,6 +4,8 @@ mod errors;
 #[cfg(test)]
 mod test_grace;
 #[cfg(test)]
+mod test_integration;
+#[cfg(test)]
 mod test_refund;
 #[cfg(test)]
 mod test_upgrades_downgrades;
@@ -239,11 +241,80 @@ impl SubscriptionContract {
             last_charged: 0,
             past_due_since: 0,
             pending_downgrade_plan_id: 0,
+            preferred_token: None,
         };
         env.storage()
             .persistent()
             .set(&DataKey::Subscription(sub_id), &sub);
         sub_id
+    }
+
+    /// Subscribe a customer to a plan with a preferred payment token.
+    /// The token must be in the accepted-tokens list. Returns the new subscription ID.
+    pub fn subscribe_with_token(env: Env, customer: Address, plan_id: u64, preferred_token: Address) -> u64 {
+        customer.require_auth();
+
+        let plan = load_plan(&env, plan_id);
+        if !plan.active {
+            panic_with_error!(&env, SubscriptionError::PlanNotActive);
+        }
+
+        let accepted: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::AcceptedTokens)
+            .unwrap_or_else(|| Vec::new(&env));
+        if !accepted.contains(&preferred_token) {
+            panic_with_error!(&env, SubscriptionError::TokenNotAccepted);
+        }
+
+        let sub_id = get_subscription_count(&env) + 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey::SubscriptionCount, &sub_id);
+
+        let sub = Subscription {
+            id: sub_id,
+            plan_id,
+            customer,
+            status: SubscriptionStatus::Active,
+            created_at: env.ledger().timestamp(),
+            last_charged: 0,
+            past_due_since: 0,
+            pending_downgrade_plan_id: 0,
+            preferred_token: Some(preferred_token),
+        };
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(sub_id), &sub);
+        sub_id
+    }
+
+    /// Update the preferred payment token for an existing subscription.
+    /// Pass `None` to revert to the plan's default token.
+    pub fn set_preferred_token(env: Env, customer: Address, sub_id: u64, preferred_token: Option<Address>) {
+        customer.require_auth();
+        let mut sub = load_subscription(&env, sub_id);
+        if sub.customer != customer {
+            panic_with_error!(&env, SubscriptionError::NotAuthorized);
+        }
+        if sub.status != SubscriptionStatus::Active {
+            panic_with_error!(&env, SubscriptionError::SubscriptionNotActive);
+        }
+        if let Some(ref token) = preferred_token {
+            let accepted: Vec<Address> = env
+                .storage()
+                .persistent()
+                .get(&DataKey::AcceptedTokens)
+                .unwrap_or_else(|| Vec::new(&env));
+            if !accepted.contains(token) {
+                panic_with_error!(&env, SubscriptionError::TokenNotAccepted);
+            }
+        }
+        sub.preferred_token = preferred_token;
+        env.storage()
+            .persistent()
+            .set(&DataKey::Subscription(sub_id), &sub);
     }
 
     pub fn get_subscription(env: Env, sub_id: u64) -> Subscription {
@@ -283,7 +354,8 @@ impl SubscriptionContract {
             .set(&DataKey::Subscription(sub_id), &sub);
 
         if is_customer {
-            let token_client = token::TokenClient::new(&env, &plan.token);
+            let billing_token = sub.preferred_token.as_ref().unwrap_or(&plan.token);
+            let token_client = token::TokenClient::new(&env, billing_token);
             let spender = env.current_contract_address();
             let current_seq = env.ledger().sequence();
             token_client.approve(&sub.customer, &spender, &0_i128, &current_seq);
@@ -312,10 +384,11 @@ impl SubscriptionContract {
             panic_with_error!(&env, SubscriptionError::SubscriptionNotActive);
         }
         let plan = load_plan(&env, sub.plan_id);
+        let billing_token = sub.preferred_token.as_ref().unwrap_or(&plan.token);
         let allowance_amount = plan.amount.saturating_mul(i128::from(cycles));
 
         let ledger_expiry = env.ledger().sequence() + 17_280 * cycles;
-        let token_client = token::TokenClient::new(&env, &plan.token);
+        let token_client = token::TokenClient::new(&env, billing_token);
         let spender = env.current_contract_address();
         token_client.approve(&customer, &spender, &allowance_amount, &ledger_expiry);
     }
@@ -326,7 +399,8 @@ impl SubscriptionContract {
     pub fn get_billing_allowance(env: Env, customer: Address, sub_id: u64) -> i128 {
         let sub = load_subscription(&env, sub_id);
         let plan = load_plan(&env, sub.plan_id);
-        let token_client = token::TokenClient::new(&env, &plan.token);
+        let billing_token = sub.preferred_token.as_ref().unwrap_or(&plan.token);
+        let token_client = token::TokenClient::new(&env, billing_token);
         let spender = env.current_contract_address();
         token_client.allowance(&customer, &spender)
     }
@@ -341,7 +415,8 @@ impl SubscriptionContract {
             panic_with_error!(&env, SubscriptionError::NotAuthorized);
         }
         let plan = load_plan(&env, sub.plan_id);
-        let token_client = token::TokenClient::new(&env, &plan.token);
+        let billing_token = sub.preferred_token.as_ref().unwrap_or(&plan.token);
+        let token_client = token::TokenClient::new(&env, billing_token);
         let spender = env.current_contract_address();
         let current_seq = env.ledger().sequence();
         token_client.approve(&customer, &spender, &0_i128, &current_seq);
@@ -369,7 +444,7 @@ impl SubscriptionContract {
             plan = load_plan(&env, sub.plan_id);
         }
 
-        let token_client = token::TokenClient::new(&env, &plan.token);
+        let token_client = token::TokenClient::new(&env, sub.preferred_token.as_ref().unwrap_or(&plan.token));
         let spender = env.current_contract_address();
 
         let allowance = token_client.allowance(&sub.customer, &spender);
@@ -506,7 +581,8 @@ impl SubscriptionContract {
         }
 
         // Pull the refund from the merchant's/creator's balance into the customer's.
-        let token_client = token::TokenClient::new(&env, &plan.token);
+        let billing_token = sub.preferred_token.as_ref().unwrap_or(&plan.token);
+        let token_client = token::TokenClient::new(&env, billing_token);
         let spender = env.current_contract_address();
         token_client.transfer_from(&spender, source, &sub.customer, &refund_amount);
 
@@ -560,7 +636,7 @@ impl SubscriptionContract {
             upgrade_cost = 0;
         }
 
-        let token_client = token::TokenClient::new(&env, &new_plan.token);
+        let token_client = token::TokenClient::new(&env, sub.preferred_token.as_ref().unwrap_or(&new_plan.token));
         let spender = env.current_contract_address();
 
         if upgrade_cost > 0 {
@@ -732,7 +808,8 @@ fn step_billing_cycle(env: &Env, sub_id: u64) -> ChargeOutcome {
 /// amount. Returns `false` if the allowance is insufficient — callers
 /// translate that into a state transition (PastDue / Terminated).
 fn try_pull_charge(env: &Env, sub: &Subscription, plan: &Plan) -> bool {
-    let token_client = token::TokenClient::new(env, &plan.token);
+    let billing_token = sub.preferred_token.as_ref().unwrap_or(&plan.token);
+    let token_client = token::TokenClient::new(env, billing_token);
     let spender = env.current_contract_address();
     let allowance = token_client.allowance(&sub.customer, &spender);
     if allowance < plan.amount {

--- a/contracts/subscription/src/test_integration.rs
+++ b/contracts/subscription/src/test_integration.rs
@@ -1,0 +1,253 @@
+/// End-to-end integration tests for cyclical billing (#297).
+///
+/// These tests simulate real scheduler behaviour: time advances in
+/// discrete steps, the billing bot calls `process_billing_cycle` each
+/// period, and we assert the full lifecycle — from subscription through
+/// multiple paid cycles, grace recovery, and eventual termination.
+use super::*;
+use crate::types::ChargeOutcome;
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::token::{StellarAssetClient, TokenClient};
+use soroban_sdk::{Address, Env, String, Vec};
+
+const MONTHLY: u64 = 2_592_000; // 30 days in seconds
+const PLAN_AMOUNT: i128 = 1_000;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+struct Fixture<'a> {
+    env: Env,
+    contract: Address,
+    client: SubscriptionContractClient<'a>,
+    merchant: Address,
+    customer: Address,
+    token: Address,
+    plan_id: u64,
+}
+
+fn setup() -> Fixture<'static> {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+    let contract = env.register(SubscriptionContract, ());
+    let client = SubscriptionContractClient::new(&env, &contract);
+
+    let admin = Address::generate(&env);
+    client.initialize(&admin);
+
+    let token_admin = Address::generate(&env);
+    let token = env
+        .register_stellar_asset_contract_v2(token_admin)
+        .address();
+    client.add_accepted_token(&token);
+
+    let merchant = Address::generate(&env);
+    let customer = Address::generate(&env);
+
+    let plan_id = client.create_plan(
+        &merchant,
+        &String::from_str(&env, "Monthly Plan"),
+        &token,
+        &PLAN_AMOUNT,
+        &MONTHLY,
+        &None,
+        &0,
+    );
+
+    Fixture { env, contract, client, merchant, customer, token, plan_id }
+}
+
+fn fund(env: &Env, token: &Address, to: &Address, amount: i128) {
+    StellarAssetClient::new(env, token).mint(to, &amount);
+}
+
+fn approve(env: &Env, token: &Address, owner: &Address, spender: &Address, amount: i128) {
+    let expiry = env.ledger().sequence() + 1_000_000;
+    TokenClient::new(env, token).approve(owner, spender, &amount, &expiry);
+}
+
+fn balance(env: &Env, token: &Address, who: &Address) -> i128 {
+    TokenClient::new(env, token).balance(who)
+}
+
+fn advance(env: &Env, seconds: u64) {
+    env.ledger().with_mut(|l| l.timestamp += seconds);
+}
+
+fn batch(env: &Env, sub_ids: &[u64]) -> Vec<u64> {
+    let mut v: Vec<u64> = Vec::new(env);
+    for id in sub_ids {
+        v.push_back(*id);
+    }
+    v
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// Simulate 6 consecutive monthly billing cycles for a single subscriber.
+/// The scheduler fires once per interval; the merchant should accumulate
+/// 6× the plan amount by the end.
+#[test]
+fn test_six_monthly_cycles_end_to_end() {
+    let f = setup();
+    fund(&f.env, &f.token, &f.customer, PLAN_AMOUNT * 6);
+    approve(&f.env, &f.token, &f.customer, &f.contract, PLAN_AMOUNT * 6);
+
+    let sub_id = f.client.subscribe(&f.customer, &f.plan_id);
+    let ids = batch(&f.env, &[sub_id]);
+
+    for cycle in 1..=6u64 {
+        let outcomes = f.client.process_billing_cycle(&ids);
+        assert_eq!(outcomes.get(0).unwrap(), ChargeOutcome::Charged, "cycle {cycle}");
+        advance(&f.env, MONTHLY);
+    }
+
+    assert_eq!(balance(&f.env, &f.token, &f.merchant), PLAN_AMOUNT * 6);
+    assert_eq!(balance(&f.env, &f.token, &f.customer), 0);
+}
+
+/// Scheduler fires every interval for multiple subscribers simultaneously.
+/// Each subscriber pays independently; merchant accumulates all funds.
+#[test]
+fn test_multi_subscriber_cyclical_billing() {
+    let f = setup();
+    let customer_a = Address::generate(&f.env);
+    let customer_b = Address::generate(&f.env);
+    let customer_c = Address::generate(&f.env);
+    let all_customers = [&customer_a, &customer_b, &customer_c];
+
+    let mut sub_ids = Vec::new(&f.env);
+    for c in all_customers.iter() {
+        fund(&f.env, &f.token, c, PLAN_AMOUNT * 3);
+        approve(&f.env, &f.token, c, &f.contract, PLAN_AMOUNT * 3);
+        sub_ids.push_back(f.client.subscribe(c, &f.plan_id));
+    }
+
+    for _ in 0..3 {
+        let outcomes = f.client.process_billing_cycle(&sub_ids);
+        for outcome in outcomes.iter() {
+            assert_eq!(outcome, ChargeOutcome::Charged);
+        }
+        advance(&f.env, MONTHLY);
+    }
+
+    assert_eq!(balance(&f.env, &f.token, &f.merchant), PLAN_AMOUNT * 9);
+}
+
+/// A subscriber misses one cycle (no allowance), enters grace, then
+/// recovers in the next scheduler pass after topping up.
+#[test]
+fn test_grace_recovery_within_cyclical_billing() {
+    let f = setup();
+    // Set a 7-day grace period.
+    f.client.set_plan_grace_period(&f.merchant, &f.plan_id, &(7 * 86_400));
+
+    let sub_id = f.client.subscribe(&f.customer, &f.plan_id);
+    let ids = batch(&f.env, &[sub_id]);
+
+    // Cycle 1: funded → Charged.
+    fund(&f.env, &f.token, &f.customer, PLAN_AMOUNT);
+    approve(&f.env, &f.token, &f.customer, &f.contract, PLAN_AMOUNT);
+    assert_eq!(f.client.process_billing_cycle(&ids).get(0).unwrap(), ChargeOutcome::Charged);
+    advance(&f.env, MONTHLY);
+
+    // Cycle 2: no allowance → EnteredGrace.
+    assert_eq!(f.client.process_billing_cycle(&ids).get(0).unwrap(), ChargeOutcome::EnteredGrace);
+
+    // Customer tops up within grace window.
+    advance(&f.env, 86_400); // 1 day into grace
+    fund(&f.env, &f.token, &f.customer, PLAN_AMOUNT);
+    approve(&f.env, &f.token, &f.customer, &f.contract, PLAN_AMOUNT);
+
+    // Cycle 2 retry: Recovered.
+    assert_eq!(f.client.process_billing_cycle(&ids).get(0).unwrap(), ChargeOutcome::Recovered);
+    assert_eq!(
+        f.client.get_subscription(&sub_id).status,
+        SubscriptionStatus::Active
+    );
+    assert_eq!(balance(&f.env, &f.token, &f.merchant), PLAN_AMOUNT * 2);
+}
+
+/// Grace window expires without recovery → subscription terminates.
+/// Subsequent scheduler passes return Skipped.
+#[test]
+fn test_grace_expiry_terminates_subscription_in_cycle() {
+    let f = setup();
+    f.client.set_plan_grace_period(&f.merchant, &f.plan_id, &86_400);
+
+    let sub_id = f.client.subscribe(&f.customer, &f.plan_id);
+    let ids = batch(&f.env, &[sub_id]);
+
+    // No allowance → EnteredGrace.
+    assert_eq!(f.client.process_billing_cycle(&ids).get(0).unwrap(), ChargeOutcome::EnteredGrace);
+
+    // Advance past grace window without recovery.
+    advance(&f.env, 86_401);
+
+    // Scheduler fires again → Terminated.
+    assert_eq!(f.client.process_billing_cycle(&ids).get(0).unwrap(), ChargeOutcome::Terminated);
+
+    // All subsequent passes → Skipped.
+    advance(&f.env, MONTHLY);
+    assert_eq!(f.client.process_billing_cycle(&ids).get(0).unwrap(), ChargeOutcome::Skipped);
+}
+
+/// Mixed batch: some subscribers active, one cancelled, one past-due.
+/// Verifies the batch never aborts and returns correct per-entry outcomes.
+#[test]
+fn test_mixed_batch_cyclical_sweep() {
+    let f = setup();
+    f.client.set_plan_grace_period(&f.merchant, &f.plan_id, &86_400);
+
+    let customer_a = Address::generate(&f.env); // will charge
+    let customer_b = Address::generate(&f.env); // will be cancelled
+    let customer_c = Address::generate(&f.env); // no allowance → grace
+
+    fund(&f.env, &f.token, &customer_a, PLAN_AMOUNT);
+    approve(&f.env, &f.token, &customer_a, &f.contract, PLAN_AMOUNT);
+
+    let sub_a = f.client.subscribe(&customer_a, &f.plan_id);
+    let sub_b = f.client.subscribe(&customer_b, &f.plan_id);
+    let sub_c = f.client.subscribe(&customer_c, &f.plan_id);
+
+    f.client.cancel_subscription(&customer_b, &sub_b);
+
+    let ids = batch(&f.env, &[sub_a, sub_b, sub_c]);
+    let outcomes = f.client.process_billing_cycle(&ids);
+
+    assert_eq!(outcomes.get(0).unwrap(), ChargeOutcome::Charged);
+    assert_eq!(outcomes.get(1).unwrap(), ChargeOutcome::Skipped);
+    assert_eq!(outcomes.get(2).unwrap(), ChargeOutcome::EnteredGrace);
+}
+
+/// Verify that `subscribe_with_token` (multi-token, #295) integrates
+/// correctly with the cyclical billing loop.
+#[test]
+fn test_multi_token_subscriber_in_cyclical_billing() {
+    let f = setup();
+
+    // Register a second accepted token.
+    let token2_admin = Address::generate(&f.env);
+    let token2 = f.env
+        .register_stellar_asset_contract_v2(token2_admin)
+        .address();
+    f.client.add_accepted_token(&token2);
+
+    // Customer subscribes using token2 as preferred payment token.
+    fund(&f.env, &token2, &f.customer, PLAN_AMOUNT * 3);
+    approve(&f.env, &token2, &f.customer, &f.contract, PLAN_AMOUNT * 3);
+
+    let sub_id = f.client.subscribe_with_token(&f.customer, &f.plan_id, &token2);
+    let ids = batch(&f.env, &[sub_id]);
+
+    for cycle in 1..=3u64 {
+        let outcomes = f.client.process_billing_cycle(&ids);
+        assert_eq!(outcomes.get(0).unwrap(), ChargeOutcome::Charged, "cycle {cycle}");
+        advance(&f.env, MONTHLY);
+    }
+
+    // Merchant received token2, not the plan's default token.
+    assert_eq!(balance(&f.env, &token2, &f.merchant), PLAN_AMOUNT * 3);
+    assert_eq!(balance(&f.env, &f.token, &f.merchant), 0);
+}

--- a/contracts/subscription/src/types.rs
+++ b/contracts/subscription/src/types.rs
@@ -65,6 +65,9 @@ pub struct Subscription {
     /// currently past due. Used to enforce the plan's grace period.
     pub past_due_since: u64,
     pub pending_downgrade_plan_id: u64,
+    /// Subscriber-preferred payment token. When `Some`, billing uses this
+    /// token instead of the plan's default token (must be an accepted token).
+    pub preferred_token: Option<Address>,
 }
 
 #[contracttype]


### PR DESCRIPTION

Resolves  Closes: #295, 
Closes #298,
Closes: #299,
Closes #297 

This PR implements four issues across the subscription and new crowdfund contracts.

#295 — Multi-token Subscription Support
Files changed: contracts/subscription/src/types.rs, contracts/subscription/src/lib.rs

Added preferred_token: Option<Address> field to the Subscription struct. When set, all billing operations (charge, authorize, revoke, cancel allowance, upgrade, and refund) use this token instead of the plan's default.

Added subscribe_with_token(customer, plan_id, preferred_token) — subscribes and stores a preferred token, validated against the accepted-tokens list.

Added set_preferred_token(customer, sub_id, preferred_token) — lets an active subscriber change their preferred token at any time (or revert to None for the plan default).

All existing billing paths (charge, process_charge, process_billing_cycle, cancel_subscription, authorize_billing, get_billing_allowance, revoke_billing_authorization, cancel_with_prorated_refund, upgrade_subscription) now resolve the billing token via sub.preferred_token.as_ref(). unwrap_or(&plan.token).

#297 — Comprehensive Integration Tests for Subscriptions
Files changed: contracts/subscription/src/test_integration.rs, contracts/subscription/src/lib.rs (module registration)

Six end-to-end tests simulating a real off-chain billing scheduler:

Test	What it covers
test_six_monthly_cycles_end_to_end	6 consecutive monthly cycles; merchant accumulates 6× plan amount
test_multi_subscriber_cyclical_billing	3 subscribers billed in parallel over 3 cycles
test_grace_recovery_within_cyclical_billing	Missed cycle → PastDue → customer tops up → Recovered
test_grace_expiry_terminates_subscription_in_cycle	Grace window expires → Terminated → subsequent passes return Skipped
test_mixed_batch_cyclical_sweep	Batch with Charged / Skipped / EnteredGrace outcomes in one sweep
test_multi_token_subscriber_in_cyclical_billing	Subscriber using a non-default token billed correctly over 3 cycles
#298 — Set Up Crowdfunding Project Contract
Files added: contracts/crowdfund/Cargo.toml, contracts/crowdfund/src/lib.rs, contracts/crowdfund/src/errors.rs, contracts/crowdfund/src/test.rs

New crowdfund Soroban contract module added to the workspace.

Defines CrowdfundContract with CrowdfundError enum.

Contract compiles to WASM cleanly.

#299 — Implement Campaign Launch Logic
Files changed: contracts/crowdfund/src/lib.rs

init_campaign(organizer, token, goal, deadline) — stores the funding goal (token base units) and deadline (Unix timestamp). Panics if already initialized, goal ≤ 0, or deadline is not in the future.

contribute(contributor, amount) — transfers tokens from contributor to the contract; panics after deadline or on zero amount.

Read-only accessors: goal(), deadline(), raised(), organizer(), goal_reached().

7 tests covering: init stores correct values, double-init panics, zero goal panics, past deadline panics, contribute increases raised, goal_reached when fully funded, contribute after deadline panics.


