### PR TITLE
feat(crowdfund): reward tiers, fulfillment tracking, milestone releases & allocation tests

### DIFF
--- a/contracts/crowdfund/src/errors.rs
+++ b/contracts/crowdfund/src/errors.rs
@@ -22,4 +22,8 @@ pub enum CrowdfundError {
     AlreadyExecuted = 11,
     // Reward for this backer has already been marked fulfilled.
     AlreadyFulfilled = 12,
+    // Contributor's total pledge is below the selected tier's minimum.
+    PledgeBelowTierMinimum = 13,
+    // The supplied tier index does not exist.
+    InvalidTier = 14,
 }

--- a/contracts/crowdfund/src/errors.rs
+++ b/contracts/crowdfund/src/errors.rs
@@ -26,4 +26,14 @@ pub enum CrowdfundError {
     PledgeBelowTierMinimum = 13,
     // The supplied tier index does not exist.
     InvalidTier = 14,
+    // No milestones have been set on this campaign.
+    MilestonesNotSet = 15,
+    // This milestone has already been released.
+    MilestoneAlreadyReleased = 16,
+    // This milestone has not yet been unlocked by the organizer.
+    MilestoneNotUnlocked = 17,
+    // Milestone percentages must be non-zero, and sum to exactly 10 000 bps (100 %).
+    InvalidMilestonePercentages = 18,
+    // Campaign is in milestone mode; use release_milestone instead of execute_campaign.
+    MilestonesActive = 19,
 }

--- a/contracts/crowdfund/src/errors.rs
+++ b/contracts/crowdfund/src/errors.rs
@@ -20,4 +20,6 @@ pub enum CrowdfundError {
     NoPledge = 10,
     // Funds have already been withdrawn by the organizer.
     AlreadyExecuted = 11,
+    // Reward for this backer has already been marked fulfilled.
+    AlreadyFulfilled = 12,
 }

--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -45,6 +45,17 @@ pub struct RewardTierSelectedEvent {
     pub tier_index: u32,
 }
 
+#[contractevent]
+pub struct MilestoneUnlockedEvent {
+    pub index: u32,
+}
+
+#[contractevent]
+pub struct MilestoneReleasedEvent {
+    pub index: u32,
+    pub amount: i128,
+}
+
 #[contracttype]
 enum DataKey {
     Organizer,
@@ -66,6 +77,12 @@ enum DataKey {
     RewardTiers,
     // Tier index selected by a specific contributor.
     SelectedTier(Address),
+    // Milestone percentages in basis points (set by organizer, must sum to 10_000).
+    MilestonePercentages,
+    // Whether the organizer has unlocked a specific milestone for release.
+    MilestoneUnlocked(u32),
+    // Whether a specific milestone's funds have been released.
+    MilestoneReleased(u32),
 }
 
 #[contract]
@@ -204,6 +221,11 @@ impl CrowdfundContract {
 
         if executed {
             panic_with_error!(&env, CrowdfundError::AlreadyExecuted);
+        }
+
+        // Milestone mode: use release_milestone instead.
+        if env.storage().persistent().has(&DataKey::MilestonePercentages) {
+            panic_with_error!(&env, CrowdfundError::MilestonesActive);
         }
 
         env.storage().persistent().set(&DataKey::Executed, &true);
@@ -398,6 +420,148 @@ impl CrowdfundContract {
         env.storage()
             .persistent()
             .get(&DataKey::SelectedTier(contributor))
+    }
+
+    /// Define milestone percentages in basis points (1 bp = 0.01 %).
+    /// Must sum to exactly 10 000, each entry > 0. Organizer-only.
+    /// Locks the campaign into milestone mode; `execute_campaign` will be blocked.
+    pub fn set_milestones(env: Env, percentages: Vec<u32>) {
+        let organizer: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Organizer)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
+
+        organizer.require_auth();
+
+        let mut sum: u32 = 0;
+        for p in percentages.iter() {
+            if p == 0 {
+                panic_with_error!(&env, CrowdfundError::InvalidMilestonePercentages);
+            }
+            sum = sum.saturating_add(p);
+        }
+        if sum != 10_000 || percentages.len() == 0 {
+            panic_with_error!(&env, CrowdfundError::InvalidMilestonePercentages);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::MilestonePercentages, &percentages);
+    }
+
+    /// Signal that a specific milestone is ready for release. Organizer-only.
+    pub fn unlock_milestone(env: Env, index: u32) {
+        let organizer: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Organizer)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
+
+        organizer.require_auth();
+
+        let percentages: Vec<u32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MilestonePercentages)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::MilestonesNotSet));
+
+        if index >= percentages.len() {
+            panic_with_error!(&env, CrowdfundError::InvalidMilestonePercentages);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::MilestoneUnlocked(index), &true);
+
+        MilestoneUnlockedEvent { index }.publish(&env);
+    }
+
+    /// Release the proportional funds for an unlocked, unreleased milestone to the organizer.
+    /// Can only be called after the campaign deadline and goal is met.
+    pub fn release_milestone(env: Env, index: u32) {
+        let organizer: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Organizer)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
+
+        organizer.require_auth();
+
+        let deadline: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Deadline)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
+
+        if env.ledger().timestamp() <= deadline {
+            panic_with_error!(&env, CrowdfundError::CampaignNotEnded);
+        }
+
+        let goal: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Goal)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
+
+        let raised: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Raised)
+            .unwrap_or(0);
+
+        if raised < goal {
+            panic_with_error!(&env, CrowdfundError::GoalNotReached);
+        }
+
+        let percentages: Vec<u32> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MilestonePercentages)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::MilestonesNotSet));
+
+        if index >= percentages.len() {
+            panic_with_error!(&env, CrowdfundError::InvalidMilestonePercentages);
+        }
+
+        let unlocked: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MilestoneUnlocked(index))
+            .unwrap_or(false);
+
+        if !unlocked {
+            panic_with_error!(&env, CrowdfundError::MilestoneNotUnlocked);
+        }
+
+        let released: bool = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MilestoneReleased(index))
+            .unwrap_or(false);
+
+        if released {
+            panic_with_error!(&env, CrowdfundError::MilestoneAlreadyReleased);
+        }
+
+        let bps = percentages.get(index).unwrap() as i128;
+        let amount = raised * bps / 10_000;
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::MilestoneReleased(index), &true);
+
+        let token_addr: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Token)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
+
+        let contract_addr = env.current_contract_address();
+        token::TokenClient::new(&env, &token_addr)
+            .transfer(&contract_addr, &organizer, &amount);
+
+        MilestoneReleasedEvent { index, amount }.publish(&env);
     }
 
     /// Returns the pledge amount recorded for a given contributor.

--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -7,7 +7,7 @@ mod test;
 use errors::CrowdfundError;
 use soroban_sdk::{
     contract, contractevent, contractimpl, contracttype, panic_with_error, token, vec, Address,
-    Env, Vec,
+    Env, String, Vec,
 };
 
 #[contractevent]
@@ -33,6 +33,19 @@ pub struct RewardFulfilledEvent {
 }
 
 #[contracttype]
+#[derive(Clone)]
+pub struct RewardTier {
+    pub min_pledge: i128,
+    pub name: String,
+}
+
+#[contractevent]
+pub struct RewardTierSelectedEvent {
+    pub contributor: Address,
+    pub tier_index: u32,
+}
+
+#[contracttype]
 enum DataKey {
     Organizer,
     Token,
@@ -49,6 +62,10 @@ enum DataKey {
     StretchTriggered(u32),
     // Tracks whether the organizer has fulfilled a specific backer's reward.
     RewardFulfilled(Address),
+    // Ordered list of reward tiers set by the organizer.
+    RewardTiers,
+    // Tier index selected by a specific contributor.
+    SelectedTier(Address),
 }
 
 #[contract]
@@ -320,6 +337,67 @@ impl CrowdfundContract {
             .persistent()
             .get(&DataKey::RewardFulfilled(backer))
             .unwrap_or(false)
+    }
+
+    /// Set reward tiers for the campaign. Tiers must be in ascending order by
+    /// `min_pledge`. Only callable by the organizer.
+    pub fn set_reward_tiers(env: Env, tiers: Vec<RewardTier>) {
+        let organizer: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Organizer)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
+
+        organizer.require_auth();
+
+        let mut prev = 0_i128;
+        for tier in tiers.iter() {
+            if tier.min_pledge <= prev {
+                panic_with_error!(&env, CrowdfundError::InvalidGoal);
+            }
+            prev = tier.min_pledge;
+        }
+
+        env.storage().persistent().set(&DataKey::RewardTiers, &tiers);
+    }
+
+    /// Select a reward tier. The contributor's total pledge must meet the tier's
+    /// `min_pledge`. Replaces any previously selected tier.
+    pub fn select_reward_tier(env: Env, contributor: Address, tier_index: u32) {
+        contributor.require_auth();
+
+        let tiers: Vec<RewardTier> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RewardTiers)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
+
+        let tier = tiers
+            .get(tier_index)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::InvalidTier));
+
+        let pledge: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Pledge(contributor.clone()))
+            .unwrap_or(0);
+
+        if pledge < tier.min_pledge {
+            panic_with_error!(&env, CrowdfundError::PledgeBelowTierMinimum);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::SelectedTier(contributor.clone()), &tier_index);
+
+        RewardTierSelectedEvent { contributor, tier_index }.publish(&env);
+    }
+
+    /// Returns the tier index selected by a contributor, or `None` if none selected.
+    pub fn get_selected_tier(env: Env, contributor: Address) -> Option<u32> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::SelectedTier(contributor))
     }
 
     /// Returns the pledge amount recorded for a given contributor.

--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -27,6 +27,11 @@ pub struct StretchGoalReachedEvent {
     pub threshold: i128,
 }
 
+#[contractevent]
+pub struct RewardFulfilledEvent {
+    pub backer: Address,
+}
+
 #[contracttype]
 enum DataKey {
     Organizer,
@@ -42,6 +47,8 @@ enum DataKey {
     StretchGoals,
     // Tracks which stretch goal indexes have already been emitted.
     StretchTriggered(u32),
+    // Tracks whether the organizer has fulfilled a specific backer's reward.
+    RewardFulfilled(Address),
 }
 
 #[contract]
@@ -278,6 +285,41 @@ impl CrowdfundContract {
         env.storage()
             .persistent()
             .set(&DataKey::StretchGoals, &milestones);
+    }
+
+    /// Mark a backer's reward as fulfilled. Only callable by the organizer.
+    /// Panics if called a second time for the same backer.
+    pub fn fulfill_reward(env: Env, backer: Address) {
+        let organizer: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Organizer)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
+
+        organizer.require_auth();
+
+        if env
+            .storage()
+            .persistent()
+            .get(&DataKey::RewardFulfilled(backer.clone()))
+            .unwrap_or(false)
+        {
+            panic_with_error!(&env, CrowdfundError::AlreadyFulfilled);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::RewardFulfilled(backer.clone()), &true);
+
+        RewardFulfilledEvent { backer }.publish(&env);
+    }
+
+    /// Returns `true` if the organizer has marked the backer's reward as fulfilled.
+    pub fn is_fulfilled(env: Env, backer: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::RewardFulfilled(backer))
+            .unwrap_or(false)
     }
 
     /// Returns the pledge amount recorded for a given contributor.

--- a/contracts/crowdfund/src/test.rs
+++ b/contracts/crowdfund/src/test.rs
@@ -557,3 +557,119 @@ fn test_release_milestone_before_deadline_panics() {
     client.unlock_milestone(&0);
     client.release_milestone(&0);
 }
+
+// ── #310 – Reward tier allocation constraints & fulfillment toggles ───────────
+
+fn tiers(env: &Env) -> soroban_sdk::Vec<RewardTier> {
+    soroban_sdk::vec![
+        env,
+        RewardTier { min_pledge: 200, name: soroban_sdk::String::from_str(env, "Silver") },
+        RewardTier { min_pledge: 1_000, name: soroban_sdk::String::from_str(env, "Gold") },
+    ]
+}
+
+#[test]
+fn test_tier_selection_at_exact_minimum_succeeds() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+    client.set_reward_tiers(&tiers(&env));
+
+    StellarAssetClient::new(&env, &token).mint(&contributor, &200);
+    client.contribute(&contributor, &200);
+
+    // Pledge == min_pledge exactly — must succeed.
+    client.select_reward_tier(&contributor, &0);
+    assert_eq!(client.get_selected_tier(&contributor), Some(0));
+}
+
+#[test]
+fn test_cumulative_pledge_unlocks_higher_tier() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+    client.set_reward_tiers(&tiers(&env));
+
+    StellarAssetClient::new(&env, &token).mint(&contributor, &1_000);
+    // Two separate contributions totalling 1_000.
+    client.contribute(&contributor, &600);
+    client.contribute(&contributor, &400);
+
+    // Total pledge 1_000 meets Gold tier minimum.
+    client.select_reward_tier(&contributor, &1);
+    assert_eq!(client.get_selected_tier(&contributor), Some(1));
+}
+
+#[test]
+fn test_fulfillment_is_independent_per_backer() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let contributor2 = Address::generate(&env);
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+
+    StellarAssetClient::new(&env, &token).mint(&contributor, &500);
+    StellarAssetClient::new(&env, &token).mint(&contributor2, &500);
+    client.contribute(&contributor, &500);
+    client.contribute(&contributor2, &500);
+
+    client.fulfill_reward(&contributor);
+
+    // contributor fulfilled, contributor2 still not.
+    assert!(client.is_fulfilled(&contributor));
+    assert!(!client.is_fulfilled(&contributor2));
+}
+
+#[test]
+fn test_fulfillment_does_not_require_tier_selection() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+
+    StellarAssetClient::new(&env, &token).mint(&contributor, &500);
+    client.contribute(&contributor, &500);
+
+    // No tier selected — fulfillment still works.
+    assert_eq!(client.get_selected_tier(&contributor), None);
+    client.fulfill_reward(&contributor);
+    assert!(client.is_fulfilled(&contributor));
+}
+
+#[test]
+#[should_panic]
+fn test_tier_one_bps_below_minimum_rejected() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+    client.set_reward_tiers(&tiers(&env));
+
+    // Pledge 199 — one below Silver minimum of 200 — must panic.
+    StellarAssetClient::new(&env, &token).mint(&contributor, &199);
+    client.contribute(&contributor, &199);
+    client.select_reward_tier(&contributor, &0);
+}
+
+#[test]
+#[should_panic]
+fn test_non_organizer_cannot_fulfill_reward() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+
+    StellarAssetClient::new(&env, &token).mint(&contributor, &500);
+    client.contribute(&contributor, &500);
+
+    // contributor tries to mark their own reward fulfilled — must panic (auth).
+    // We disable mock_all_auths for this check by not using the default setup env.
+    // Since setup() calls mock_all_auths, we verify the contract still guards via
+    // the organizer.require_auth() by using a fresh env without mocked auths.
+    let env2 = Env::default();
+    let contract2 = env2.register(CrowdfundContract, ());
+    let client2 = CrowdfundContractClient::new(&env2, &contract2);
+    env2.ledger().with_mut(|l| l.timestamp = 1_000_000);
+    let org2 = Address::generate(&env2);
+    let tok2 = env2.register_stellar_asset_contract_v2(org2.clone()).address();
+    let con2 = Address::generate(&env2);
+    client2.init_campaign(&org2, &tok2, &100, &(env2.ledger().timestamp() + 1_000));
+    // No mock_all_auths — calling fulfill_reward as non-organizer must panic.
+    client2.fulfill_reward(&con2);
+}

--- a/contracts/crowdfund/src/test.rs
+++ b/contracts/crowdfund/src/test.rs
@@ -369,3 +369,95 @@ fn test_is_fulfilled_default_false() {
 
     assert!(!client.is_fulfilled(&contributor));
 }
+
+// ── #308 – Reward tiers ───────────────────────────────────────────────────────
+
+#[test]
+fn test_select_reward_tier_maps_pledge_to_tier() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+
+    client.set_reward_tiers(&soroban_sdk::vec![
+        &env,
+        RewardTier { min_pledge: 100, name: soroban_sdk::String::from_str(&env, "Basic") },
+        RewardTier { min_pledge: 500, name: soroban_sdk::String::from_str(&env, "Premium") },
+    ]);
+
+    StellarAssetClient::new(&env, &token).mint(&contributor, &500);
+    client.contribute(&contributor, &500);
+
+    // Contributor has 500 — can select tier 1 (min 500).
+    client.select_reward_tier(&contributor, &1);
+    assert_eq!(client.get_selected_tier(&contributor), Some(1));
+}
+
+#[test]
+fn test_select_reward_tier_can_be_updated() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+
+    client.set_reward_tiers(&soroban_sdk::vec![
+        &env,
+        RewardTier { min_pledge: 100, name: soroban_sdk::String::from_str(&env, "Basic") },
+        RewardTier { min_pledge: 500, name: soroban_sdk::String::from_str(&env, "Premium") },
+    ]);
+
+    StellarAssetClient::new(&env, &token).mint(&contributor, &600);
+    client.contribute(&contributor, &600);
+
+    client.select_reward_tier(&contributor, &0);
+    assert_eq!(client.get_selected_tier(&contributor), Some(0));
+
+    // Upgrade to tier 1.
+    client.select_reward_tier(&contributor, &1);
+    assert_eq!(client.get_selected_tier(&contributor), Some(1));
+}
+
+#[test]
+#[should_panic]
+fn test_select_reward_tier_below_minimum_panics() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+
+    client.set_reward_tiers(&soroban_sdk::vec![
+        &env,
+        RewardTier { min_pledge: 500, name: soroban_sdk::String::from_str(&env, "Premium") },
+    ]);
+
+    StellarAssetClient::new(&env, &token).mint(&contributor, &100);
+    client.contribute(&contributor, &100);
+
+    // Only 100 pledged, tier requires 500 — must panic.
+    client.select_reward_tier(&contributor, &0);
+}
+
+#[test]
+#[should_panic]
+fn test_select_invalid_tier_index_panics() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+
+    client.set_reward_tiers(&soroban_sdk::vec![
+        &env,
+        RewardTier { min_pledge: 100, name: soroban_sdk::String::from_str(&env, "Basic") },
+    ]);
+
+    StellarAssetClient::new(&env, &token).mint(&contributor, &500);
+    client.contribute(&contributor, &500);
+
+    // Tier index 5 doesn't exist — must panic.
+    client.select_reward_tier(&contributor, &5);
+}
+
+#[test]
+fn test_get_selected_tier_returns_none_before_selection() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+
+    assert_eq!(client.get_selected_tier(&contributor), None);
+}

--- a/contracts/crowdfund/src/test.rs
+++ b/contracts/crowdfund/src/test.rs
@@ -461,3 +461,99 @@ fn test_get_selected_tier_returns_none_before_selection() {
 
     assert_eq!(client.get_selected_tier(&contributor), None);
 }
+
+// ── #311 – Milestone-based fund release ──────────────────────────────────────
+
+fn setup_milestone_campaign() -> (Env, Address, CrowdfundContractClient<'static>, Address, Address, Address) {
+    let (env, contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &10_000, &deadline);
+    // 3 milestones: 50%, 30%, 20% in basis points
+    client.set_milestones(&soroban_sdk::vec![&env, 5_000_u32, 3_000_u32, 2_000_u32]);
+    StellarAssetClient::new(&env, &token).mint(&contributor, &10_000);
+    client.contribute(&contributor, &10_000);
+    // Advance past deadline
+    env.ledger().with_mut(|l| l.timestamp += 86_401);
+    (env, contract, client, token, organizer, contributor)
+}
+
+#[test]
+fn test_release_milestone_transfers_correct_amount() {
+    let (env, _contract, client, token, organizer, _contributor) = setup_milestone_campaign();
+
+    client.unlock_milestone(&0);
+    client.release_milestone(&0);
+
+    // 50% of 10_000 = 5_000
+    assert_eq!(
+        soroban_sdk::token::TokenClient::new(&env, &token).balance(&organizer),
+        5_000
+    );
+}
+
+#[test]
+fn test_all_milestones_release_full_raised_amount() {
+    let (env, _contract, client, token, organizer, _contributor) = setup_milestone_campaign();
+
+    client.unlock_milestone(&0);
+    client.release_milestone(&0);
+    client.unlock_milestone(&1);
+    client.release_milestone(&1);
+    client.unlock_milestone(&2);
+    client.release_milestone(&2);
+
+    // 50% + 30% + 20% = 100% of 10_000
+    assert_eq!(
+        soroban_sdk::token::TokenClient::new(&env, &token).balance(&organizer),
+        10_000
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_release_milestone_without_unlock_panics() {
+    let (_env, _contract, client, _token, _organizer, _contributor) = setup_milestone_campaign();
+    // Milestone 0 not unlocked — must panic
+    client.release_milestone(&0);
+}
+
+#[test]
+#[should_panic]
+fn test_release_milestone_twice_panics() {
+    let (_env, _contract, client, _token, _organizer, _contributor) = setup_milestone_campaign();
+    client.unlock_milestone(&0);
+    client.release_milestone(&0);
+    client.release_milestone(&0); // must panic
+}
+
+#[test]
+#[should_panic]
+fn test_execute_campaign_blocked_in_milestone_mode() {
+    let (_env, _contract, client, _token, _organizer, _contributor) = setup_milestone_campaign();
+    // MilestonesActive error expected
+    client.execute_campaign();
+}
+
+#[test]
+#[should_panic]
+fn test_set_milestones_invalid_sum_panics() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+    // Sums to 9_000, not 10_000 — must panic
+    client.set_milestones(&soroban_sdk::vec![&env, 5_000_u32, 4_000_u32]);
+}
+
+#[test]
+#[should_panic]
+fn test_release_milestone_before_deadline_panics() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+    client.set_milestones(&soroban_sdk::vec![&env, 10_000_u32]);
+    StellarAssetClient::new(&env, &token).mint(&contributor, &1_000);
+    client.contribute(&contributor, &1_000);
+    // Deadline not yet passed — must panic
+    client.unlock_milestone(&0);
+    client.release_milestone(&0);
+}

--- a/contracts/crowdfund/src/test.rs
+++ b/contracts/crowdfund/src/test.rs
@@ -330,3 +330,42 @@ fn test_set_stretch_goals_non_ascending_panics() {
     // 5_000 then 2_000 is not ascending — must panic.
     client.set_stretch_goals(&vec![&env, 5_000_i128, 2_000_i128]);
 }
+
+// ── #309 – Reward fulfillment tracking ───────────────────────────────────────
+
+#[test]
+fn test_fulfill_reward_marks_backer_as_fulfilled() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+
+    StellarAssetClient::new(&env, &token).mint(&contributor, &1_000);
+    client.contribute(&contributor, &1_000);
+
+    assert!(!client.is_fulfilled(&contributor));
+    client.fulfill_reward(&contributor);
+    assert!(client.is_fulfilled(&contributor));
+}
+
+#[test]
+#[should_panic]
+fn test_fulfill_reward_twice_panics() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+
+    StellarAssetClient::new(&env, &token).mint(&contributor, &1_000);
+    client.contribute(&contributor, &1_000);
+
+    client.fulfill_reward(&contributor);
+    client.fulfill_reward(&contributor); // must panic
+}
+
+#[test]
+fn test_is_fulfilled_default_false() {
+    let (env, _contract, client, token, organizer, contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &1_000, &deadline);
+
+    assert!(!client.is_fulfilled(&contributor));
+}


### PR DESCRIPTION
## Summary

This PR implements four issues against the `crowdfund` contract, all changes are in `contracts/crowdfund/src/`.

---

### Closes #309 — Track Claimed Physical vs Digital Rewards

**Files:** `lib.rs`, `errors.rs`, `test.rs`

- Added `RewardFulfilled(Address)` DataKey to persist per-backer fulfillment state.
- Added `RewardFulfilledEvent { backer }` contract event.
- Added `AlreadyFulfilled = 12` error.
- Added `fulfill_reward(backer)` — organizer-only; marks a backer's reward as fulfilled; panics on duplicate calls.
- Added `is_fulfilled(backer) -> bool` — read-only accessor.
- 3 tests: happy path, double-fulfill panic, default `false`.

---

### Closes #308 — Reward Tiers Implementation

**Files:** `lib.rs`, `errors.rs`, `test.rs`

- Added `RewardTier { min_pledge: i128, name: String }` contracttype struct.
- Added `RewardTiers` and `SelectedTier(Address)` DataKeys.
- Added `RewardTierSelectedEvent { contributor, tier_index }`.
- Added `PledgeBelowTierMinimum = 13` and `InvalidTier = 14` errors.
- Added `set_reward_tiers(tiers)` — organizer-only; validates ascending `min_pledge` order.
- Added `select_reward_tier(contributor, tier_index)` — validates contributor's total pledge meets tier minimum; replaces any prior selection.
- Added `get_selected_tier(contributor) -> Option<u32>` — read-only accessor.
- 5 tests: happy path, tier upgrade, below-minimum panic, invalid index panic, default `None`.

---

### Closes #311 — Implement Milestone-based Fund Release

**Files:** `lib.rs`, `errors.rs`, `test.rs`

Funds are now dispersible in phases instead of a lump sum. Percentages are expressed in basis points (10 000 bps = 100%).

- Added `MilestonePercentages`, `MilestoneUnlocked(u32)`, `MilestoneReleased(u32)` DataKeys.
- Added `MilestoneUnlockedEvent` and `MilestoneReleasedEvent { index, amount }`.
- Added errors: `MilestonesNotSet = 15`, `MilestoneAlreadyReleased = 16`, `MilestoneNotUnlocked = 17`, `InvalidMilestonePercentages = 18`, `MilestonesActive = 19`.
- Added `set_milestones(percentages)` — organizer-only; all entries > 0, must sum to exactly 10 000.
- Added `unlock_milestone(index)` — organizer signals a phase is ready for release.
- Added `release_milestone(index)` — post-deadline, goal-met; transfers `raised * bps / 10_000` to organizer; prevents double-release.
- Guarded `execute_campaign` to panic with `MilestonesActive` when milestone mode is active.
- 7 tests: correct proportional amount, full 100% payout across all milestones, missing unlock panic, double-release panic, `execute_campaign` guard, invalid bps sum, pre-deadline release panic.

---

### Closes #310 — Add Tests for Reward Tier Allocations

**Files:** `test.rs`

Additional constraint and integration tests to harden tier selection and fulfillment:

- `test_tier_selection_at_exact_minimum_succeeds` — boundary: pledge == `min_pledge` is accepted.
- `test_cumulative_pledge_unlocks_higher_tier` — multiple contributions are summed correctly for tier gating.
- `test_fulfillment_is_independent_per_backer` — fulfilling one backer does not affect others.
- `test_fulfillment_does_not_require_tier_selection` — fulfillment and tier selection are orthogonal.
- `test_tier_one_bps_below_minimum_rejected` — pledge exactly 1 below minimum is rejected.
- `test_non_organizer_cannot_fulfill_reward` — `organizer.require_auth()` blocks non-organizers.

---

## What was tested

All logic was verified via static code review (Rust/Cargo toolchain not available in the dev container). Tests follow the existing patterns in the test suite.