### PR TITLE
feat(crowdfund_factory): add campaign approval proposal system

### DIFF
--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -10,11 +10,13 @@ use soroban_sdk::{
     vec, Address, Env, String, Vec,
 };
 
+#[allow(dead_code)]
 #[contractclient(name = "InvoicePaymentClient")]
 trait InvoicePayment {
     fn pay_invoice(env: Env, payer: Address, invoice_id: u64);
 }
 
+#[allow(dead_code)]
 #[contractclient(name = "MerchantAccountRefundClient")]
 trait MerchantAccountRefund {
     fn refund(env: Env, token: Address, amount: i128, to: Address);
@@ -92,6 +94,7 @@ pub struct PledgeCommentAddedEvent {
     pub comment: String,
 }
 
+#[contractevent]
 pub struct PledgeReceivedEvent {
     pub contributor: Address,
     pub amount: i128,
@@ -166,13 +169,7 @@ impl CrowdfundContract {
     /// * `token`     – accepted payment token.
     /// * `goal`      – target amount in token base units (must be > 0).
     /// * `deadline`  – Unix timestamp of the campaign end (must be in the future).
-    pub fn init_campaign(
-        env: Env,
-        organizer: Address,
-        token: Address,
-        goal: i128,
-        deadline: u64,
-    ) {
+    pub fn init_campaign(env: Env, organizer: Address, token: Address, goal: i128, deadline: u64) {
         if env.storage().persistent().has(&DataKey::Organizer) {
             panic_with_error!(&env, CrowdfundError::AlreadyInitialized);
         }
@@ -183,83 +180,139 @@ impl CrowdfundContract {
             panic_with_error!(&env, CrowdfundError::InvalidDeadline);
         }
 
-        env.storage().persistent().set(&DataKey::Organizer, &organizer);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Organizer, &organizer);
         env.storage().persistent().set(&DataKey::Token, &token);
         env.storage().persistent().set(&DataKey::Goal, &goal);
-        env.storage().persistent().set(&DataKey::Deadline, &deadline);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Deadline, &deadline);
         env.storage().persistent().set(&DataKey::Raised, &0_i128);
         env.storage().persistent().set(&DataKey::Executed, &false);
-        env.storage().persistent().set(&DataKey::RefundProcessed, &false);
-        env.storage().persistent().set(&DataKey::Contributors, &Vec::<Address>::new(&env));
+        env.storage()
+            .persistent()
+            .set(&DataKey::RefundProcessed, &false);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contributors, &Vec::<Address>::new(&env));
     }
 
     /// Set the Shade gateway contract address. Only callable once by the organizer.
     pub fn set_shade_gateway(env: Env, shade_gateway: Address) {
-        let organizer: Address = env.storage().persistent().get(&DataKey::Organizer)
+        let organizer: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Organizer)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
         organizer.require_auth();
         if env.storage().persistent().has(&DataKey::ShadeGateway) {
             panic_with_error!(&env, CrowdfundError::AlreadyInitialized);
         }
-        env.storage().persistent().set(&DataKey::ShadeGateway, &shade_gateway);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ShadeGateway, &shade_gateway);
     }
 
     /// Register this campaign's Shade merchant ID. Only callable once by the organizer.
     pub fn set_merchant_id(env: Env, merchant_id: u64) {
-        let organizer: Address = env.storage().persistent().get(&DataKey::Organizer)
+        let organizer: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Organizer)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
         organizer.require_auth();
         if env.storage().persistent().has(&DataKey::MerchantId) {
             panic_with_error!(&env, CrowdfundError::AlreadyInitialized);
         }
-        env.storage().persistent().set(&DataKey::MerchantId, &merchant_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::MerchantId, &merchant_id);
     }
 
     /// Set the Shade merchant account address for refunds. Only callable once by the organizer.
     pub fn set_merchant_account(env: Env, merchant_account: Address) {
-        let organizer: Address = env.storage().persistent().get(&DataKey::Organizer)
+        let organizer: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Organizer)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
         organizer.require_auth();
         if env.storage().persistent().has(&DataKey::MerchantAccount) {
             panic_with_error!(&env, CrowdfundError::AlreadyInitialized);
         }
-        env.storage().persistent().set(&DataKey::MerchantAccount, &merchant_account);
+        env.storage()
+            .persistent()
+            .set(&DataKey::MerchantAccount, &merchant_account);
     }
 
     /// Process a pledge through the Shade gateway (#300).
     pub fn pledge(env: Env, contributor: Address, amount: i128, invoice_id: u64) {
         contributor.require_auth();
-        if amount <= 0 { panic_with_error!(&env, CrowdfundError::InvalidAmount); }
+        if amount <= 0 {
+            panic_with_error!(&env, CrowdfundError::InvalidAmount);
+        }
 
-        let deadline: u64 = env.storage().persistent().get(&DataKey::Deadline)
+        let deadline: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Deadline)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
-        if env.ledger().timestamp() > deadline { panic_with_error!(&env, CrowdfundError::CampaignEnded); }
-        if env.storage().persistent().get(&DataKey::Executed).unwrap_or(false) {
+        if env.ledger().timestamp() > deadline {
+            panic_with_error!(&env, CrowdfundError::CampaignEnded);
+        }
+        if env
+            .storage()
+            .persistent()
+            .get(&DataKey::Executed)
+            .unwrap_or(false)
+        {
             panic_with_error!(&env, CrowdfundError::AlreadyExecuted);
         }
 
-        let shade_gateway: Address = env.storage().persistent().get(&DataKey::ShadeGateway)
+        let shade_gateway: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ShadeGateway)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::ShadeGatewayNotSet));
-        let token_addr: Address = env.storage().persistent().get(&DataKey::Token)
+        let token_addr: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Token)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
 
         InvoicePaymentClient::new(&env, &shade_gateway).pay_invoice(&contributor, &invoice_id);
 
-        let merchant_account: Address = env.storage().persistent().get(&DataKey::MerchantAccount)
+        let merchant_account: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MerchantAccount)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::MerchantAccountNotSet));
-        MerchantAccountRefundClient::new(&env, &merchant_account)
-            .refund(&token_addr, &amount, &env.current_contract_address());
+        MerchantAccountRefundClient::new(&env, &merchant_account).refund(
+            &token_addr,
+            &amount,
+            &env.current_contract_address(),
+        );
 
         let new_raised = Self::apply_pledge_with_matching(&env, contributor.clone(), amount);
 
-        let prev: i128 = env.storage().persistent()
-            .get(&DataKey::Pledge(contributor.clone())).unwrap_or(0);
-        env.storage().persistent()
-            .set(&DataKey::Pledge(contributor.clone()), &prev.saturating_add(amount));
+        let prev: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Pledge(contributor.clone()))
+            .unwrap_or(0);
+        env.storage().persistent().set(
+            &DataKey::Pledge(contributor.clone()),
+            &prev.saturating_add(amount),
+        );
 
         Self::track_contributor(&env, contributor.clone());
         Self::check_stretch_goals(&env, new_raised);
-        PledgeReceivedEvent { contributor, amount }.publish(&env);
+        PledgeReceivedEvent {
+            contributor,
+            amount,
+        }
+        .publish(&env);
     }
 
     /// Contribute `amount` tokens to the campaign. The caller must have
@@ -290,8 +343,7 @@ impl CrowdfundContract {
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
 
         let contract_addr = env.current_contract_address();
-        token::TokenClient::new(&env, &token_addr)
-            .transfer(&contributor, &contract_addr, &amount);
+        token::TokenClient::new(&env, &token_addr).transfer(&contributor, &contract_addr, &amount);
 
         let new_raised = Self::apply_pledge_with_matching(&env, contributor.clone(), amount);
 
@@ -317,7 +369,11 @@ impl CrowdfundContract {
         let contract_addr = env.current_contract_address();
         token::TokenClient::new(&env, &token_addr).transfer(&sponsor, &contract_addr, &amount);
 
-        let current: i128 = env.storage().persistent().get(&DataKey::MatchingPool).unwrap_or(0);
+        let current: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MatchingPool)
+            .unwrap_or(0);
         env.storage()
             .persistent()
             .set(&DataKey::MatchingPool, &current.saturating_add(amount));
@@ -342,7 +398,11 @@ impl CrowdfundContract {
         env.storage()
             .persistent()
             .set(&DataKey::PledgeComment(contributor.clone()), &comment);
-        PledgeCommentAddedEvent { contributor, comment }.publish(&env);
+        PledgeCommentAddedEvent {
+            contributor,
+            comment,
+        }
+        .publish(&env);
     }
 
     /// Retrieve a contributor's public pledge comment, if any.
@@ -354,7 +414,10 @@ impl CrowdfundContract {
 
     /// Read the currently available sponsor matching pool.
     pub fn matching_pool_balance(env: Env) -> i128 {
-        env.storage().persistent().get(&DataKey::MatchingPool).unwrap_or(0)
+        env.storage()
+            .persistent()
+            .get(&DataKey::MatchingPool)
+            .unwrap_or(0)
     }
 
     /// Withdraw funds to the organizer after deadline if goal was met (#303).
@@ -404,7 +467,11 @@ impl CrowdfundContract {
         }
 
         // Milestone mode: use release_milestone instead.
-        if env.storage().persistent().has(&DataKey::MilestonePercentages) {
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::MilestonePercentages)
+        {
             panic_with_error!(&env, CrowdfundError::MilestonesActive);
         }
 
@@ -417,8 +484,7 @@ impl CrowdfundContract {
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
 
         let contract_addr = env.current_contract_address();
-        token::TokenClient::new(&env, &token_addr)
-            .transfer(&contract_addr, &organizer, &raised);
+        token::TokenClient::new(&env, &token_addr).transfer(&contract_addr, &organizer, &raised);
 
         CampaignExecutedEvent { amount: raised }.publish(&env);
     }
@@ -475,52 +541,89 @@ impl CrowdfundContract {
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
 
         let contract_addr = env.current_contract_address();
-        token::TokenClient::new(&env, &token_addr)
-            .transfer(&contract_addr, &contributor, &pledge);
+        token::TokenClient::new(&env, &token_addr).transfer(&contract_addr, &contributor, &pledge);
 
-        RefundClaimedEvent { contributor: contributor.clone(), amount: pledge }.publish(&env);
+        RefundClaimedEvent {
+            contributor: contributor.clone(),
+            amount: pledge,
+        }
+        .publish(&env);
     }
 
     /// Batch refund all contributors after a failed campaign (#307).
     /// Callable by anyone once deadline has passed and goal was not met.
     pub fn batch_refund(env: Env) {
-        let deadline: u64 = env.storage().persistent().get(&DataKey::Deadline)
+        let deadline: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Deadline)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
         if env.ledger().timestamp() <= deadline {
             panic_with_error!(&env, CrowdfundError::CampaignNotEnded);
         }
 
-        let goal: i128 = env.storage().persistent().get(&DataKey::Goal)
+        let goal: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Goal)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
-        let raised: i128 = env.storage().persistent().get(&DataKey::Raised).unwrap_or(0);
-        if raised >= goal { panic_with_error!(&env, CrowdfundError::GoalReached); }
+        let raised: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Raised)
+            .unwrap_or(0);
+        if raised >= goal {
+            panic_with_error!(&env, CrowdfundError::GoalReached);
+        }
 
-        if env.storage().persistent().get(&DataKey::RefundProcessed).unwrap_or(false) {
+        if env
+            .storage()
+            .persistent()
+            .get(&DataKey::RefundProcessed)
+            .unwrap_or(false)
+        {
             panic_with_error!(&env, CrowdfundError::RefundAlreadyProcessed);
         }
-        env.storage().persistent().set(&DataKey::RefundProcessed, &true);
+        env.storage()
+            .persistent()
+            .set(&DataKey::RefundProcessed, &true);
 
-        let token_addr: Address = env.storage().persistent().get(&DataKey::Token)
+        let token_addr: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Token)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
         let token_client = token::TokenClient::new(&env, &token_addr);
         let contract_addr = env.current_contract_address();
 
-        let contributors: Vec<Address> = env.storage().persistent()
-            .get(&DataKey::Contributors).unwrap_or_else(|| Vec::new(&env));
+        let contributors: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Contributors)
+            .unwrap_or_else(|| Vec::new(&env));
         let count = contributors.len();
         let mut total_refunded: i128 = 0;
 
         for contributor in contributors.iter() {
-            let pledge: i128 = env.storage().persistent()
-                .get(&DataKey::Pledge(contributor.clone())).unwrap_or(0);
+            let pledge: i128 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Pledge(contributor.clone()))
+                .unwrap_or(0);
             if pledge > 0 {
-                env.storage().persistent().set(&DataKey::Pledge(contributor.clone()), &0_i128);
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::Pledge(contributor.clone()), &0_i128);
                 token_client.transfer(&contract_addr, &contributor, &pledge);
                 total_refunded = total_refunded.saturating_add(pledge);
             }
         }
 
-        BatchRefundProcessedEvent { total_refunded, contributor_count: count }.publish(&env);
+        BatchRefundProcessedEvent {
+            total_refunded,
+            contributor_count: count,
+        }
+        .publish(&env);
     }
 
     /// Add ordered stretch goal milestones (must be in ascending order, all > goal) (#306).
@@ -602,7 +705,9 @@ impl CrowdfundContract {
             prev = tier.min_pledge;
         }
 
-        env.storage().persistent().set(&DataKey::RewardTiers, &tiers);
+        env.storage()
+            .persistent()
+            .set(&DataKey::RewardTiers, &tiers);
     }
 
     /// Select a reward tier. The contributor's total pledge must meet the tier's
@@ -634,7 +739,11 @@ impl CrowdfundContract {
             .persistent()
             .set(&DataKey::SelectedTier(contributor.clone()), &tier_index);
 
-        RewardTierSelectedEvent { contributor, tier_index }.publish(&env);
+        RewardTierSelectedEvent {
+            contributor,
+            tier_index,
+        }
+        .publish(&env);
     }
 
     /// Returns the tier index selected by a contributor, or `None` if none selected.
@@ -663,7 +772,7 @@ impl CrowdfundContract {
             }
             sum = sum.saturating_add(p);
         }
-        if sum != 10_000 || percentages.len() == 0 {
+        if sum != 10_000 || percentages.is_empty() {
             panic_with_error!(&env, CrowdfundError::InvalidMilestonePercentages);
         }
 
@@ -741,7 +850,13 @@ impl CrowdfundContract {
             .set(&tally_key, &current.saturating_add(weight));
         env.storage().persistent().set(&vote_key, &approve);
 
-        MilestoneVoteCastEvent { index, voter, approve, weight }.publish(&env);
+        MilestoneVoteCastEvent {
+            index,
+            voter,
+            approve,
+            weight,
+        }
+        .publish(&env);
     }
 
     /// Release the proportional funds for an unlocked, unreleased milestone to the organizer.
@@ -835,8 +950,7 @@ impl CrowdfundContract {
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
 
         let contract_addr = env.current_contract_address();
-        token::TokenClient::new(&env, &token_addr)
-            .transfer(&contract_addr, &organizer, &amount);
+        token::TokenClient::new(&env, &token_addr).transfer(&contract_addr, &organizer, &amount);
 
         MilestoneReleasedEvent { index, amount }.publish(&env);
     }
@@ -906,13 +1020,20 @@ impl CrowdfundContract {
     /// Emit a `stretch / reached` event for each milestone crossed by `new_raised`
     /// that has not already been triggered.
     fn track_contributor(env: &Env, contributor: Address) {
-        let mut contributors: Vec<Address> = env.storage().persistent()
-            .get(&DataKey::Contributors).unwrap_or_else(|| Vec::new(env));
+        let mut contributors: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Contributors)
+            .unwrap_or_else(|| Vec::new(env));
         for c in contributors.iter() {
-            if c == contributor { return; }
+            if c == contributor {
+                return;
+            }
         }
         contributors.push_back(contributor);
-        env.storage().persistent().set(&DataKey::Contributors, &contributors);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contributors, &contributors);
     }
 
     fn check_stretch_goals(env: &Env, new_raised: i128) {
@@ -944,7 +1065,11 @@ impl CrowdfundContract {
     }
 
     fn apply_pledge_with_matching(env: &Env, contributor: Address, amount: i128) -> i128 {
-        let matching_pool: i128 = env.storage().persistent().get(&DataKey::MatchingPool).unwrap_or(0);
+        let matching_pool: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MatchingPool)
+            .unwrap_or(0);
         let matched_amount = if matching_pool >= amount {
             amount
         } else {
@@ -963,18 +1088,25 @@ impl CrowdfundContract {
         }
 
         let effective_amount = amount.saturating_add(matched_amount);
-        let raised: i128 = env.storage().persistent().get(&DataKey::Raised).unwrap_or(0);
+        let raised: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Raised)
+            .unwrap_or(0);
         let new_raised = raised.saturating_add(effective_amount);
-        env.storage().persistent().set(&DataKey::Raised, &new_raised);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Raised, &new_raised);
 
         let prev_pledge: i128 = env
             .storage()
             .persistent()
             .get(&DataKey::Pledge(contributor.clone()))
             .unwrap_or(0);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Pledge(contributor), &prev_pledge.saturating_add(effective_amount));
+        env.storage().persistent().set(
+            &DataKey::Pledge(contributor),
+            &prev_pledge.saturating_add(effective_amount),
+        );
 
         new_raised
     }

--- a/contracts/crowdfund/src/test.rs
+++ b/contracts/crowdfund/src/test.rs
@@ -3,7 +3,14 @@ use soroban_sdk::testutils::{Address as _, Ledger as _};
 use soroban_sdk::token::StellarAssetClient;
 use soroban_sdk::{vec, Address, Env};
 
-fn setup() -> (Env, Address, CrowdfundContractClient<'static>, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    Address,
+    CrowdfundContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
     env.ledger().with_mut(|l| l.timestamp = 1_000_000);
@@ -380,8 +387,14 @@ fn test_select_reward_tier_maps_pledge_to_tier() {
 
     client.set_reward_tiers(&soroban_sdk::vec![
         &env,
-        RewardTier { min_pledge: 100, name: soroban_sdk::String::from_str(&env, "Basic") },
-        RewardTier { min_pledge: 500, name: soroban_sdk::String::from_str(&env, "Premium") },
+        RewardTier {
+            min_pledge: 100,
+            name: soroban_sdk::String::from_str(&env, "Basic")
+        },
+        RewardTier {
+            min_pledge: 500,
+            name: soroban_sdk::String::from_str(&env, "Premium")
+        },
     ]);
 
     StellarAssetClient::new(&env, &token).mint(&contributor, &500);
@@ -400,8 +413,14 @@ fn test_select_reward_tier_can_be_updated() {
 
     client.set_reward_tiers(&soroban_sdk::vec![
         &env,
-        RewardTier { min_pledge: 100, name: soroban_sdk::String::from_str(&env, "Basic") },
-        RewardTier { min_pledge: 500, name: soroban_sdk::String::from_str(&env, "Premium") },
+        RewardTier {
+            min_pledge: 100,
+            name: soroban_sdk::String::from_str(&env, "Basic")
+        },
+        RewardTier {
+            min_pledge: 500,
+            name: soroban_sdk::String::from_str(&env, "Premium")
+        },
     ]);
 
     StellarAssetClient::new(&env, &token).mint(&contributor, &600);
@@ -424,7 +443,10 @@ fn test_select_reward_tier_below_minimum_panics() {
 
     client.set_reward_tiers(&soroban_sdk::vec![
         &env,
-        RewardTier { min_pledge: 500, name: soroban_sdk::String::from_str(&env, "Premium") },
+        RewardTier {
+            min_pledge: 500,
+            name: soroban_sdk::String::from_str(&env, "Premium")
+        },
     ]);
 
     StellarAssetClient::new(&env, &token).mint(&contributor, &100);
@@ -443,7 +465,10 @@ fn test_select_invalid_tier_index_panics() {
 
     client.set_reward_tiers(&soroban_sdk::vec![
         &env,
-        RewardTier { min_pledge: 100, name: soroban_sdk::String::from_str(&env, "Basic") },
+        RewardTier {
+            min_pledge: 100,
+            name: soroban_sdk::String::from_str(&env, "Basic")
+        },
     ]);
 
     StellarAssetClient::new(&env, &token).mint(&contributor, &500);
@@ -464,7 +489,14 @@ fn test_get_selected_tier_returns_none_before_selection() {
 
 // ── #311 – Milestone-based fund release ──────────────────────────────────────
 
-fn setup_milestone_campaign() -> (Env, Address, CrowdfundContractClient<'static>, Address, Address, Address) {
+fn setup_milestone_campaign() -> (
+    Env,
+    Address,
+    CrowdfundContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let (env, contract, client, token, organizer, contributor) = setup();
     let deadline = env.ledger().timestamp() + 86_400;
     client.init_campaign(&organizer, &token, &10_000, &deadline);
@@ -508,7 +540,9 @@ fn setup_governed_milestone_campaign() -> (
 
     env.ledger().with_mut(|l| l.timestamp += 86_401);
 
-    (env, contract, client, token, organizer, voter1, voter2, voter3)
+    (
+        env, contract, client, token, organizer, voter1, voter2, voter3,
+    )
 }
 
 #[test]
@@ -664,8 +698,14 @@ fn milestone_without_majority_cannot_release_funds() {
 fn tiers(env: &Env) -> soroban_sdk::Vec<RewardTier> {
     soroban_sdk::vec![
         env,
-        RewardTier { min_pledge: 200, name: soroban_sdk::String::from_str(env, "Silver") },
-        RewardTier { min_pledge: 1_000, name: soroban_sdk::String::from_str(env, "Gold") },
+        RewardTier {
+            min_pledge: 200,
+            name: soroban_sdk::String::from_str(env, "Silver")
+        },
+        RewardTier {
+            min_pledge: 1_000,
+            name: soroban_sdk::String::from_str(env, "Gold")
+        },
     ]
 }
 
@@ -768,7 +808,9 @@ fn test_non_organizer_cannot_fulfill_reward() {
     let client2 = CrowdfundContractClient::new(&env2, &contract2);
     env2.ledger().with_mut(|l| l.timestamp = 1_000_000);
     let org2 = Address::generate(&env2);
-    let tok2 = env2.register_stellar_asset_contract_v2(org2.clone()).address();
+    let tok2 = env2
+        .register_stellar_asset_contract_v2(org2.clone())
+        .address();
     let con2 = Address::generate(&env2);
     client2.init_campaign(&org2, &tok2, &100, &(env2.ledger().timestamp() + 1_000));
     // No mock_all_auths — calling fulfill_reward as non-organizer must panic.

--- a/contracts/crowdfund_factory/src/errors.rs
+++ b/contracts/crowdfund_factory/src/errors.rs
@@ -8,4 +8,15 @@ pub enum FactoryError {
     AlreadyInitialized = 2,
     WasmHashNotSet = 3,
     CampaignNotFound = 4,
+    // Governance has not been initialised via `init_governance` (#358).
+    GovernanceNotInitialized = 5,
+    // Caller is neither the governance admin nor a granted reviewer.
+    NotReviewer = 6,
+    InvalidGoal = 7,
+    InvalidDeadline = 8,
+    ProposalNotFound = 9,
+    // Proposal is not in `Pending` status.
+    ProposalNotPending = 10,
+    // Proposal is not in `Approved` status.
+    ProposalNotApproved = 11,
 }

--- a/contracts/crowdfund_factory/src/lib.rs
+++ b/contracts/crowdfund_factory/src/lib.rs
@@ -6,8 +6,8 @@ mod test;
 
 use crate::errors::FactoryError;
 use soroban_sdk::{
-    contract, contractevent, contractimpl, contracttype, panic_with_error, Address, Bytes,
-    BytesN, Env, IntoVal, Symbol, Vec,
+    contract, contractevent, contractimpl, contracttype, panic_with_error, Address, Bytes, BytesN,
+    Env, IntoVal, String, Symbol, Vec,
 };
 
 #[derive(Clone, Debug, Eq, PartialEq)]
@@ -19,12 +19,39 @@ pub struct CampaignRef {
     pub deployed_at: u64,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+#[contracttype]
+pub enum ProposalStatus {
+    Pending,
+    Approved,
+    Rejected,
+    Executed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+#[contracttype]
+pub struct CampaignProposal {
+    pub id: u64,
+    pub organizer: Address,
+    pub token: Address,
+    pub goal: i128,
+    pub deadline: u64,
+    pub status: ProposalStatus,
+    pub created_at: u64,
+}
+
 #[derive(Clone)]
 #[contracttype]
 enum DataKey {
     CrowdfundWasmHash,
     CampaignRef(u64),
     CampaignRefCount,
+    // Governance admin, authorised to grant/revoke reviewers (#358).
+    Admin,
+    // Whether a given address may approve/reject campaign proposals (#358).
+    Reviewer(Address),
+    CampaignProposal(u64),
+    CampaignProposalCount,
 }
 
 #[contractevent]
@@ -35,11 +62,86 @@ pub struct CampaignDeployedEvent {
     pub deployed_at: u64,
 }
 
+#[contractevent]
+pub struct ReviewerGrantedEvent {
+    pub reviewer: Address,
+    pub granted_by: Address,
+}
+
+#[contractevent]
+pub struct ReviewerRevokedEvent {
+    pub reviewer: Address,
+    pub revoked_by: Address,
+}
+
+#[contractevent]
+pub struct CampaignProposalCreatedEvent {
+    pub proposal_id: u64,
+    pub organizer: Address,
+    pub token: Address,
+    pub goal: i128,
+    pub deadline: u64,
+    pub created_at: u64,
+}
+
+#[contractevent]
+pub struct CampaignProposalApprovedEvent {
+    pub proposal_id: u64,
+    pub reviewer: Address,
+    pub approved_at: u64,
+}
+
+#[contractevent]
+pub struct CampaignProposalRejectedEvent {
+    pub proposal_id: u64,
+    pub reviewer: Address,
+    pub reason: String,
+    pub rejected_at: u64,
+}
+
+#[contractevent]
+pub struct CampaignProposalExecutedEvent {
+    pub proposal_id: u64,
+    pub campaign_id: u64,
+    pub contract: Address,
+    pub executed_at: u64,
+}
+
 fn get_campaign_count(env: &Env) -> u64 {
     env.storage()
         .persistent()
         .get(&DataKey::CampaignRefCount)
         .unwrap_or(0)
+}
+
+fn get_campaign_proposal_count(env: &Env) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CampaignProposalCount)
+        .unwrap_or(0)
+}
+
+fn get_admin(env: &Env) -> Address {
+    env.storage()
+        .persistent()
+        .get(&DataKey::Admin)
+        .unwrap_or_else(|| panic_with_error!(env, FactoryError::GovernanceNotInitialized))
+}
+
+fn require_reviewer(env: &Env, caller: &Address) {
+    caller.require_auth();
+    let admin: Address = get_admin(env);
+    if *caller == admin {
+        return;
+    }
+    let is_reviewer: bool = env
+        .storage()
+        .persistent()
+        .get(&DataKey::Reviewer(caller.clone()))
+        .unwrap_or(false);
+    if !is_reviewer {
+        panic_with_error!(env, FactoryError::NotReviewer);
+    }
 }
 
 #[contract]
@@ -77,26 +179,38 @@ impl CrowdfundFactory {
         deadline: u64,
     ) -> CampaignRef {
         organizer.require_auth();
+        Self::deploy_campaign_internal(&env, organizer, token, goal, deadline)
+    }
 
+    fn deploy_campaign_internal(
+        env: &Env,
+        organizer: Address,
+        token: Address,
+        goal: i128,
+        deadline: u64,
+    ) -> CampaignRef {
         let wasm_hash: BytesN<32> = env
             .storage()
             .persistent()
             .get(&DataKey::CrowdfundWasmHash)
-            .unwrap_or_else(|| panic_with_error!(&env, FactoryError::WasmHashNotSet));
+            .unwrap_or_else(|| panic_with_error!(env, FactoryError::WasmHashNotSet));
 
         let random: BytesN<32> = env.prng().gen();
         let salt = env
             .crypto()
-            .keccak256(&Bytes::from_slice(&env, &random.to_array()));
+            .keccak256(&Bytes::from_slice(env, &random.to_array()));
 
-        let campaign_addr = env.deployer().with_current_contract(salt).deploy_v2(wasm_hash, ());
+        let campaign_addr = env
+            .deployer()
+            .with_current_contract(salt)
+            .deploy_v2(wasm_hash, ());
         env.invoke_contract::<()>(
             &campaign_addr,
-            &Symbol::new(&env, "init_campaign"),
-            (organizer.clone(), token, goal, deadline).into_val(&env),
+            &Symbol::new(env, "init_campaign"),
+            (organizer.clone(), token, goal, deadline).into_val(env),
         );
 
-        let campaign_id = get_campaign_count(&env) + 1;
+        let campaign_id = get_campaign_count(env) + 1;
         let deployed_at = env.ledger().timestamp();
         let campaign_ref = CampaignRef {
             campaign_id,
@@ -117,6 +231,221 @@ impl CrowdfundFactory {
             contract: campaign_addr,
             organizer,
             deployed_at,
+        }
+        .publish(env);
+
+        campaign_ref
+    }
+
+    // ── Campaign approval governance (#358) ──────────────────────────────────
+
+    /// One-time setup of the governance admin. Independent of `initialize`
+    /// so existing deployments can adopt governance without redeploying.
+    pub fn init_governance(env: Env, admin: Address) {
+        admin.require_auth();
+        if env.storage().persistent().has(&DataKey::Admin) {
+            panic_with_error!(&env, FactoryError::AlreadyInitialized);
+        }
+        env.storage().persistent().set(&DataKey::Admin, &admin);
+    }
+
+    pub fn get_governance_admin(env: Env) -> Address {
+        get_admin(&env)
+    }
+
+    /// Grant an address permission to approve/reject campaign proposals.
+    pub fn grant_reviewer(env: Env, admin: Address, reviewer: Address) {
+        admin.require_auth();
+        if admin != get_admin(&env) {
+            panic_with_error!(&env, FactoryError::NotReviewer);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::Reviewer(reviewer.clone()), &true);
+        ReviewerGrantedEvent {
+            reviewer,
+            granted_by: admin,
+        }
+        .publish(&env);
+    }
+
+    /// Revoke a previously granted reviewer's approval rights.
+    pub fn revoke_reviewer(env: Env, admin: Address, reviewer: Address) {
+        admin.require_auth();
+        if admin != get_admin(&env) {
+            panic_with_error!(&env, FactoryError::NotReviewer);
+        }
+        env.storage()
+            .persistent()
+            .set(&DataKey::Reviewer(reviewer.clone()), &false);
+        ReviewerRevokedEvent {
+            reviewer,
+            revoked_by: admin,
+        }
+        .publish(&env);
+    }
+
+    pub fn is_reviewer(env: Env, address: Address) -> bool {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Reviewer(address))
+            .unwrap_or(false)
+    }
+
+    /// Organizer submits a campaign for governance approval instead of
+    /// deploying directly via `deploy_campaign`.
+    pub fn propose_campaign(
+        env: Env,
+        organizer: Address,
+        token: Address,
+        goal: i128,
+        deadline: u64,
+    ) -> u64 {
+        organizer.require_auth();
+        if !env.storage().persistent().has(&DataKey::Admin) {
+            panic_with_error!(&env, FactoryError::GovernanceNotInitialized);
+        }
+        if goal <= 0 {
+            panic_with_error!(&env, FactoryError::InvalidGoal);
+        }
+        if deadline <= env.ledger().timestamp() {
+            panic_with_error!(&env, FactoryError::InvalidDeadline);
+        }
+
+        let proposal_id = get_campaign_proposal_count(&env) + 1;
+        let created_at = env.ledger().timestamp();
+        let proposal = CampaignProposal {
+            id: proposal_id,
+            organizer: organizer.clone(),
+            token: token.clone(),
+            goal,
+            deadline,
+            status: ProposalStatus::Pending,
+            created_at,
+        };
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::CampaignProposal(proposal_id), &proposal);
+        env.storage()
+            .persistent()
+            .set(&DataKey::CampaignProposalCount, &proposal_id);
+
+        CampaignProposalCreatedEvent {
+            proposal_id,
+            organizer,
+            token,
+            goal,
+            deadline,
+            created_at,
+        }
+        .publish(&env);
+
+        proposal_id
+    }
+
+    pub fn get_campaign_proposal(env: Env, proposal_id: u64) -> CampaignProposal {
+        env.storage()
+            .persistent()
+            .get(&DataKey::CampaignProposal(proposal_id))
+            .unwrap_or_else(|| panic_with_error!(&env, FactoryError::ProposalNotFound))
+    }
+
+    pub fn get_campaign_proposal_count(env: Env) -> u64 {
+        get_campaign_proposal_count(&env)
+    }
+
+    /// Admin or a granted reviewer approves a pending proposal.
+    pub fn approve_campaign_proposal(env: Env, reviewer: Address, proposal_id: u64) {
+        require_reviewer(&env, &reviewer);
+
+        let mut proposal: CampaignProposal = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CampaignProposal(proposal_id))
+            .unwrap_or_else(|| panic_with_error!(&env, FactoryError::ProposalNotFound));
+
+        if proposal.status != ProposalStatus::Pending {
+            panic_with_error!(&env, FactoryError::ProposalNotPending);
+        }
+
+        proposal.status = ProposalStatus::Approved;
+        env.storage()
+            .persistent()
+            .set(&DataKey::CampaignProposal(proposal_id), &proposal);
+
+        let approved_at = env.ledger().timestamp();
+        CampaignProposalApprovedEvent {
+            proposal_id,
+            reviewer,
+            approved_at,
+        }
+        .publish(&env);
+    }
+
+    /// Admin or a granted reviewer rejects a pending proposal.
+    pub fn reject_campaign_proposal(env: Env, reviewer: Address, proposal_id: u64, reason: String) {
+        require_reviewer(&env, &reviewer);
+
+        let mut proposal: CampaignProposal = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CampaignProposal(proposal_id))
+            .unwrap_or_else(|| panic_with_error!(&env, FactoryError::ProposalNotFound));
+
+        if proposal.status != ProposalStatus::Pending {
+            panic_with_error!(&env, FactoryError::ProposalNotPending);
+        }
+
+        proposal.status = ProposalStatus::Rejected;
+        env.storage()
+            .persistent()
+            .set(&DataKey::CampaignProposal(proposal_id), &proposal);
+
+        let rejected_at = env.ledger().timestamp();
+        CampaignProposalRejectedEvent {
+            proposal_id,
+            reviewer,
+            reason,
+            rejected_at,
+        }
+        .publish(&env);
+    }
+
+    /// Deploy the campaign contract for an approved proposal. Callable only
+    /// by the proposal's organizer.
+    pub fn execute_campaign_proposal(env: Env, proposal_id: u64) -> CampaignRef {
+        let mut proposal: CampaignProposal = env
+            .storage()
+            .persistent()
+            .get(&DataKey::CampaignProposal(proposal_id))
+            .unwrap_or_else(|| panic_with_error!(&env, FactoryError::ProposalNotFound));
+
+        proposal.organizer.require_auth();
+
+        if proposal.status != ProposalStatus::Approved {
+            panic_with_error!(&env, FactoryError::ProposalNotApproved);
+        }
+
+        proposal.status = ProposalStatus::Executed;
+        env.storage()
+            .persistent()
+            .set(&DataKey::CampaignProposal(proposal_id), &proposal);
+
+        let campaign_ref = Self::deploy_campaign_internal(
+            &env,
+            proposal.organizer.clone(),
+            proposal.token.clone(),
+            proposal.goal,
+            proposal.deadline,
+        );
+
+        let executed_at = env.ledger().timestamp();
+        CampaignProposalExecutedEvent {
+            proposal_id,
+            campaign_id: campaign_ref.campaign_id,
+            contract: campaign_ref.contract.clone(),
+            executed_at,
         }
         .publish(&env);
 

--- a/contracts/crowdfund_factory/src/test.rs
+++ b/contracts/crowdfund_factory/src/test.rs
@@ -1,10 +1,19 @@
 #![cfg(test)]
 
 use super::*;
-use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{Address, BytesN, Env};
+use soroban_sdk::testutils::{Address as _, Ledger as _};
+use soroban_sdk::{Address, BytesN, Env, String};
 
-fn register_campaign_ref(env: &Env, factory_id: &Address, organizer: Address, contract: Address) -> CampaignRef {
+mod crowdfund_wasm {
+    soroban_sdk::contractimport!(file = "../../target/wasm32v1-none/release/crowdfund.wasm");
+}
+
+fn register_campaign_ref(
+    env: &Env,
+    factory_id: &Address,
+    organizer: Address,
+    contract: Address,
+) -> CampaignRef {
     env.as_contract(factory_id, || {
         let campaign_id = get_campaign_count(env) + 1;
         let deployed_at = env.ledger().timestamp();
@@ -37,8 +46,18 @@ fn test_deploy_campaign_tracks_active_protocols() {
 
     let organizer_a = Address::generate(&env);
     let organizer_b = Address::generate(&env);
-    let campaign_a = register_campaign_ref(&env, &factory_id, organizer_a.clone(), Address::generate(&env));
-    let campaign_b = register_campaign_ref(&env, &factory_id, organizer_b.clone(), Address::generate(&env));
+    let campaign_a = register_campaign_ref(
+        &env,
+        &factory_id,
+        organizer_a.clone(),
+        Address::generate(&env),
+    );
+    let campaign_b = register_campaign_ref(
+        &env,
+        &factory_id,
+        organizer_b.clone(),
+        Address::generate(&env),
+    );
 
     assert_eq!(factory.get_campaign_count(), 2);
     assert_eq!(campaign_a.campaign_id, 1);
@@ -48,4 +67,265 @@ fn test_deploy_campaign_tracks_active_protocols() {
     assert_eq!(campaigns.len(), 2);
     assert_eq!(campaigns.get_unchecked(0).organizer, organizer_a);
     assert_eq!(campaigns.get_unchecked(1).organizer, organizer_b);
+}
+
+// ── Campaign approval governance (#358) ──────────────────────────────────────
+
+fn setup_governance(env: &Env) -> (CrowdfundFactoryClient<'static>, Address, Address) {
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+    let factory_id = env.register(CrowdfundFactory, ());
+    let factory = CrowdfundFactoryClient::new(env, &factory_id);
+    let crowdfund_wasm_hash = env.deployer().upload_contract_wasm(crowdfund_wasm::WASM);
+    factory.initialize(&crowdfund_wasm_hash);
+
+    let admin = Address::generate(env);
+    factory.init_governance(&admin);
+
+    (factory, factory_id, admin)
+}
+
+#[test]
+fn test_propose_campaign_creates_pending_proposal() {
+    let env = Env::default();
+    let (factory, _factory_id, _admin) = setup_governance(&env);
+
+    let organizer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let deadline = env.ledger().timestamp() + 86_400;
+
+    let proposal_id = factory.propose_campaign(&organizer, &token, &10_000, &deadline);
+    assert_eq!(proposal_id, 1);
+
+    let proposal = factory.get_campaign_proposal(&proposal_id);
+    assert_eq!(proposal.organizer, organizer);
+    assert_eq!(proposal.token, token);
+    assert_eq!(proposal.goal, 10_000);
+    assert_eq!(proposal.deadline, deadline);
+    assert_eq!(proposal.status, ProposalStatus::Pending);
+    assert_eq!(factory.get_campaign_proposal_count(), 1);
+}
+
+#[test]
+#[should_panic]
+fn test_propose_campaign_without_governance_panics() {
+    let env = Env::default();
+    env.mock_all_auths();
+    env.ledger().with_mut(|l| l.timestamp = 1_000_000);
+
+    let factory_id = env.register(CrowdfundFactory, ());
+    let factory = CrowdfundFactoryClient::new(&env, &factory_id);
+    let crowdfund_wasm_hash = env.deployer().upload_contract_wasm(crowdfund_wasm::WASM);
+    factory.initialize(&crowdfund_wasm_hash);
+
+    let organizer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let deadline = env.ledger().timestamp() + 86_400;
+    factory.propose_campaign(&organizer, &token, &10_000, &deadline);
+}
+
+#[test]
+#[should_panic]
+fn test_propose_campaign_invalid_goal_panics() {
+    let env = Env::default();
+    let (factory, _factory_id, _admin) = setup_governance(&env);
+    let organizer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let deadline = env.ledger().timestamp() + 86_400;
+    factory.propose_campaign(&organizer, &token, &0, &deadline);
+}
+
+#[test]
+#[should_panic]
+fn test_propose_campaign_past_deadline_panics() {
+    let env = Env::default();
+    let (factory, _factory_id, _admin) = setup_governance(&env);
+    let organizer = Address::generate(&env);
+    let token = Address::generate(&env);
+    factory.propose_campaign(&organizer, &token, &10_000, &(env.ledger().timestamp() - 1));
+}
+
+#[test]
+fn test_admin_can_approve_proposal_directly() {
+    let env = Env::default();
+    let (factory, _factory_id, admin) = setup_governance(&env);
+    let organizer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let deadline = env.ledger().timestamp() + 86_400;
+
+    let proposal_id = factory.propose_campaign(&organizer, &token, &10_000, &deadline);
+    factory.approve_campaign_proposal(&admin, &proposal_id);
+
+    let proposal = factory.get_campaign_proposal(&proposal_id);
+    assert_eq!(proposal.status, ProposalStatus::Approved);
+}
+
+#[test]
+fn test_grant_and_revoke_reviewer() {
+    let env = Env::default();
+    let (factory, _factory_id, admin) = setup_governance(&env);
+    let reviewer = Address::generate(&env);
+
+    assert!(!factory.is_reviewer(&reviewer));
+    factory.grant_reviewer(&admin, &reviewer);
+    assert!(factory.is_reviewer(&reviewer));
+    factory.revoke_reviewer(&admin, &reviewer);
+    assert!(!factory.is_reviewer(&reviewer));
+}
+
+#[test]
+#[should_panic]
+fn test_non_admin_cannot_grant_reviewer() {
+    let env = Env::default();
+    let (factory, _factory_id, _admin) = setup_governance(&env);
+    let not_admin = Address::generate(&env);
+    let reviewer = Address::generate(&env);
+    factory.grant_reviewer(&not_admin, &reviewer);
+}
+
+#[test]
+fn test_granted_reviewer_can_approve_proposal() {
+    let env = Env::default();
+    let (factory, _factory_id, admin) = setup_governance(&env);
+    let reviewer = Address::generate(&env);
+    factory.grant_reviewer(&admin, &reviewer);
+
+    let organizer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let deadline = env.ledger().timestamp() + 86_400;
+    let proposal_id = factory.propose_campaign(&organizer, &token, &10_000, &deadline);
+
+    factory.approve_campaign_proposal(&reviewer, &proposal_id);
+    assert_eq!(
+        factory.get_campaign_proposal(&proposal_id).status,
+        ProposalStatus::Approved
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_unauthorized_address_cannot_approve_proposal() {
+    let env = Env::default();
+    let (factory, _factory_id, _admin) = setup_governance(&env);
+    let organizer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let deadline = env.ledger().timestamp() + 86_400;
+    let proposal_id = factory.propose_campaign(&organizer, &token, &10_000, &deadline);
+
+    let malicious = Address::generate(&env);
+    factory.approve_campaign_proposal(&malicious, &proposal_id);
+}
+
+#[test]
+fn test_reject_proposal_sets_status_and_blocks_further_action() {
+    let env = Env::default();
+    let (factory, _factory_id, admin) = setup_governance(&env);
+    let organizer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let deadline = env.ledger().timestamp() + 86_400;
+    let proposal_id = factory.propose_campaign(&organizer, &token, &10_000, &deadline);
+
+    let reason = String::from_str(&env, "insufficient documentation");
+    factory.reject_campaign_proposal(&admin, &proposal_id, &reason);
+
+    assert_eq!(
+        factory.get_campaign_proposal(&proposal_id).status,
+        ProposalStatus::Rejected
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_cannot_approve_already_rejected_proposal() {
+    let env = Env::default();
+    let (factory, _factory_id, admin) = setup_governance(&env);
+    let organizer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let deadline = env.ledger().timestamp() + 86_400;
+    let proposal_id = factory.propose_campaign(&organizer, &token, &10_000, &deadline);
+
+    let reason = String::from_str(&env, "no");
+    factory.reject_campaign_proposal(&admin, &proposal_id, &reason);
+    factory.approve_campaign_proposal(&admin, &proposal_id);
+}
+
+#[test]
+#[should_panic]
+fn test_cannot_approve_already_approved_proposal() {
+    let env = Env::default();
+    let (factory, _factory_id, admin) = setup_governance(&env);
+    let organizer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let deadline = env.ledger().timestamp() + 86_400;
+    let proposal_id = factory.propose_campaign(&organizer, &token, &10_000, &deadline);
+
+    factory.approve_campaign_proposal(&admin, &proposal_id);
+    factory.approve_campaign_proposal(&admin, &proposal_id);
+}
+
+#[test]
+fn test_execute_approved_proposal_deploys_campaign() {
+    let env = Env::default();
+    let (factory, _factory_id, admin) = setup_governance(&env);
+    let organizer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let deadline = env.ledger().timestamp() + 86_400;
+    let proposal_id = factory.propose_campaign(&organizer, &token, &10_000, &deadline);
+
+    factory.approve_campaign_proposal(&admin, &proposal_id);
+    let campaign_ref = factory.execute_campaign_proposal(&proposal_id);
+
+    assert_eq!(campaign_ref.campaign_id, 1);
+    assert_eq!(campaign_ref.organizer, organizer);
+    assert_eq!(factory.get_campaign_count(), 1);
+    assert_eq!(
+        factory.get_campaign_proposal(&proposal_id).status,
+        ProposalStatus::Executed
+    );
+}
+
+#[test]
+#[should_panic]
+fn test_execute_pending_proposal_panics() {
+    let env = Env::default();
+    let (factory, _factory_id, _admin) = setup_governance(&env);
+    let organizer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let deadline = env.ledger().timestamp() + 86_400;
+    let proposal_id = factory.propose_campaign(&organizer, &token, &10_000, &deadline);
+
+    factory.execute_campaign_proposal(&proposal_id);
+}
+
+#[test]
+#[should_panic]
+fn test_execute_proposal_twice_panics() {
+    let env = Env::default();
+    let (factory, _factory_id, admin) = setup_governance(&env);
+    let organizer = Address::generate(&env);
+    let token = Address::generate(&env);
+    let deadline = env.ledger().timestamp() + 86_400;
+    let proposal_id = factory.propose_campaign(&organizer, &token, &10_000, &deadline);
+
+    factory.approve_campaign_proposal(&admin, &proposal_id);
+    factory.execute_campaign_proposal(&proposal_id);
+    factory.execute_campaign_proposal(&proposal_id);
+}
+
+#[test]
+#[should_panic]
+fn test_get_nonexistent_proposal_panics() {
+    let env = Env::default();
+    let (factory, _factory_id, _admin) = setup_governance(&env);
+    factory.get_campaign_proposal(&999);
+}
+
+#[test]
+#[should_panic]
+fn test_double_init_governance_panics() {
+    let env = Env::default();
+    let (factory, _factory_id, _admin) = setup_governance(&env);
+    let other_admin = Address::generate(&env);
+    factory.init_governance(&other_admin);
 }


### PR DESCRIPTION
## Summary
- Adds a governance proposal/approval flow to `crowdfund_factory` for campaign creation: organizers call `propose_campaign` instead of deploying directly.
- Admin (`init_governance`) can grant/revoke `reviewer` roles via `grant_reviewer`/`revoke_reviewer`.
- Admin or a granted reviewer approves/rejects pending proposals (`approve_campaign_proposal` / `reject_campaign_proposal`).
- Organizer executes an approved proposal (`execute_campaign_proposal`), which deploys through the existing `deploy_campaign` path.
- New events for full lifecycle: `CampaignProposalCreatedEvent`, `CampaignProposalApprovedEvent`, `CampaignProposalRejectedEvent`, `CampaignProposalExecutedEvent`, `ReviewerGrantedEvent`, `ReviewerRevokedEvent`.
- `deploy_campaign` is untouched and still works directly (backward compatible); governance is opt-in via `init_governance`.
- Storage kept minimal: proposal struct only stores what's needed to deploy + audit; reviewer flags are single bools keyed by address.
- Fixes a pre-existing compile error in `crowdfund` (`PledgeReceivedEvent` missing `#[contractevent]`) and two clippy lints, required because `crowdfund_factory`'s test suite dev-depends on `crowdfund`.

## Test plan
- [x] `cargo fmt -p crowdfund -p crowdfund_factory -- --check`
- [x] `cargo clippy -p crowdfund -p crowdfund_factory --all-targets -- -D warnings`
- [x] `cargo test -p crowdfund -p crowdfund_factory` — 58 + 18 tests passing, including full happy path, unauthorized access, and double-approval/execution edge cases for the new proposal flow (verified against a real deployed `crowdfund` wasm via `contractimport!`)

Closes #358