### PR TITLE
feat(crowdfund): add social recovery for campaign creator accounts

### DIFF
--- a/contracts/crowdfund/src/errors.rs
+++ b/contracts/crowdfund/src/errors.rs
@@ -52,4 +52,18 @@ pub enum CrowdfundError {
     InsufficientMatchingPool = 26,
     // Pledge comment exceeds the configured maximum length.
     CommentTooLong = 27,
+    // Guardians have not been configured for this campaign (#366).
+    GuardiansNotSet = 28,
+    // Caller is not a configured guardian.
+    NotGuardian = 29,
+    // Threshold must be > 0 and <= guardian count.
+    InvalidThreshold = 30,
+    // Guardian list contains a duplicate address.
+    DuplicateGuardian = 31,
+    // A recovery is already pending; cancel or let it execute first.
+    RecoveryAlreadyPending = 32,
+    // No recovery is currently pending.
+    NoPendingRecovery = 33,
+    // This guardian has already approved the pending recovery.
+    AlreadyApprovedRecovery = 34,
 }

--- a/contracts/crowdfund/src/lib.rs
+++ b/contracts/crowdfund/src/lib.rs
@@ -10,11 +10,13 @@ use soroban_sdk::{
     vec, Address, Env, String, Vec,
 };
 
+#[allow(dead_code)]
 #[contractclient(name = "InvoicePaymentClient")]
 trait InvoicePayment {
     fn pay_invoice(env: Env, payer: Address, invoice_id: u64);
 }
 
+#[allow(dead_code)]
 #[contractclient(name = "MerchantAccountRefundClient")]
 trait MerchantAccountRefund {
     fn refund(env: Env, token: Address, amount: i128, to: Address);
@@ -92,6 +94,7 @@ pub struct PledgeCommentAddedEvent {
     pub comment: String,
 }
 
+#[contractevent]
 pub struct PledgeReceivedEvent {
     pub contributor: Address,
     pub amount: i128,
@@ -101,6 +104,38 @@ pub struct PledgeReceivedEvent {
 pub struct BatchRefundProcessedEvent {
     pub total_refunded: i128,
     pub contributor_count: u32,
+}
+
+#[contractevent]
+pub struct GuardiansSetEvent {
+    pub organizer: Address,
+    pub guardian_count: u32,
+    pub threshold: u32,
+}
+
+#[contractevent]
+pub struct RecoveryInitiatedEvent {
+    pub initiator: Address,
+    pub nominee: Address,
+}
+
+#[contractevent]
+pub struct RecoveryApprovedEvent {
+    pub guardian: Address,
+    pub approvals: u32,
+    pub threshold: u32,
+}
+
+#[contractevent]
+pub struct RecoveryExecutedEvent {
+    pub old_organizer: Address,
+    pub new_organizer: Address,
+}
+
+#[contractevent]
+pub struct RecoveryCancelledEvent {
+    pub organizer: Address,
+    pub nominee: Address,
 }
 
 #[contracttype]
@@ -149,6 +184,16 @@ enum DataKey {
     MatchingPool,
     // Public comment attached to a contributor pledge.
     PledgeComment(Address),
+    // Guardian addresses configured for social recovery of this campaign (#366).
+    Guardians,
+    // Number of guardian approvals required to execute a recovery.
+    GuardianThreshold,
+    // Address nominated to become organizer if recovery succeeds.
+    RecoveryNominee,
+    // Tracks whether a specific guardian has approved the pending recovery.
+    RecoveryApproval(Address),
+    // Count of approvals collected for the pending recovery.
+    RecoveryApprovalCount,
 }
 
 #[contract]
@@ -166,13 +211,7 @@ impl CrowdfundContract {
     /// * `token`     – accepted payment token.
     /// * `goal`      – target amount in token base units (must be > 0).
     /// * `deadline`  – Unix timestamp of the campaign end (must be in the future).
-    pub fn init_campaign(
-        env: Env,
-        organizer: Address,
-        token: Address,
-        goal: i128,
-        deadline: u64,
-    ) {
+    pub fn init_campaign(env: Env, organizer: Address, token: Address, goal: i128, deadline: u64) {
         if env.storage().persistent().has(&DataKey::Organizer) {
             panic_with_error!(&env, CrowdfundError::AlreadyInitialized);
         }
@@ -183,83 +222,139 @@ impl CrowdfundContract {
             panic_with_error!(&env, CrowdfundError::InvalidDeadline);
         }
 
-        env.storage().persistent().set(&DataKey::Organizer, &organizer);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Organizer, &organizer);
         env.storage().persistent().set(&DataKey::Token, &token);
         env.storage().persistent().set(&DataKey::Goal, &goal);
-        env.storage().persistent().set(&DataKey::Deadline, &deadline);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Deadline, &deadline);
         env.storage().persistent().set(&DataKey::Raised, &0_i128);
         env.storage().persistent().set(&DataKey::Executed, &false);
-        env.storage().persistent().set(&DataKey::RefundProcessed, &false);
-        env.storage().persistent().set(&DataKey::Contributors, &Vec::<Address>::new(&env));
+        env.storage()
+            .persistent()
+            .set(&DataKey::RefundProcessed, &false);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contributors, &Vec::<Address>::new(&env));
     }
 
     /// Set the Shade gateway contract address. Only callable once by the organizer.
     pub fn set_shade_gateway(env: Env, shade_gateway: Address) {
-        let organizer: Address = env.storage().persistent().get(&DataKey::Organizer)
+        let organizer: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Organizer)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
         organizer.require_auth();
         if env.storage().persistent().has(&DataKey::ShadeGateway) {
             panic_with_error!(&env, CrowdfundError::AlreadyInitialized);
         }
-        env.storage().persistent().set(&DataKey::ShadeGateway, &shade_gateway);
+        env.storage()
+            .persistent()
+            .set(&DataKey::ShadeGateway, &shade_gateway);
     }
 
     /// Register this campaign's Shade merchant ID. Only callable once by the organizer.
     pub fn set_merchant_id(env: Env, merchant_id: u64) {
-        let organizer: Address = env.storage().persistent().get(&DataKey::Organizer)
+        let organizer: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Organizer)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
         organizer.require_auth();
         if env.storage().persistent().has(&DataKey::MerchantId) {
             panic_with_error!(&env, CrowdfundError::AlreadyInitialized);
         }
-        env.storage().persistent().set(&DataKey::MerchantId, &merchant_id);
+        env.storage()
+            .persistent()
+            .set(&DataKey::MerchantId, &merchant_id);
     }
 
     /// Set the Shade merchant account address for refunds. Only callable once by the organizer.
     pub fn set_merchant_account(env: Env, merchant_account: Address) {
-        let organizer: Address = env.storage().persistent().get(&DataKey::Organizer)
+        let organizer: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Organizer)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
         organizer.require_auth();
         if env.storage().persistent().has(&DataKey::MerchantAccount) {
             panic_with_error!(&env, CrowdfundError::AlreadyInitialized);
         }
-        env.storage().persistent().set(&DataKey::MerchantAccount, &merchant_account);
+        env.storage()
+            .persistent()
+            .set(&DataKey::MerchantAccount, &merchant_account);
     }
 
     /// Process a pledge through the Shade gateway (#300).
     pub fn pledge(env: Env, contributor: Address, amount: i128, invoice_id: u64) {
         contributor.require_auth();
-        if amount <= 0 { panic_with_error!(&env, CrowdfundError::InvalidAmount); }
+        if amount <= 0 {
+            panic_with_error!(&env, CrowdfundError::InvalidAmount);
+        }
 
-        let deadline: u64 = env.storage().persistent().get(&DataKey::Deadline)
+        let deadline: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Deadline)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
-        if env.ledger().timestamp() > deadline { panic_with_error!(&env, CrowdfundError::CampaignEnded); }
-        if env.storage().persistent().get(&DataKey::Executed).unwrap_or(false) {
+        if env.ledger().timestamp() > deadline {
+            panic_with_error!(&env, CrowdfundError::CampaignEnded);
+        }
+        if env
+            .storage()
+            .persistent()
+            .get(&DataKey::Executed)
+            .unwrap_or(false)
+        {
             panic_with_error!(&env, CrowdfundError::AlreadyExecuted);
         }
 
-        let shade_gateway: Address = env.storage().persistent().get(&DataKey::ShadeGateway)
+        let shade_gateway: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::ShadeGateway)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::ShadeGatewayNotSet));
-        let token_addr: Address = env.storage().persistent().get(&DataKey::Token)
+        let token_addr: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Token)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
 
         InvoicePaymentClient::new(&env, &shade_gateway).pay_invoice(&contributor, &invoice_id);
 
-        let merchant_account: Address = env.storage().persistent().get(&DataKey::MerchantAccount)
+        let merchant_account: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MerchantAccount)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::MerchantAccountNotSet));
-        MerchantAccountRefundClient::new(&env, &merchant_account)
-            .refund(&token_addr, &amount, &env.current_contract_address());
+        MerchantAccountRefundClient::new(&env, &merchant_account).refund(
+            &token_addr,
+            &amount,
+            &env.current_contract_address(),
+        );
 
         let new_raised = Self::apply_pledge_with_matching(&env, contributor.clone(), amount);
 
-        let prev: i128 = env.storage().persistent()
-            .get(&DataKey::Pledge(contributor.clone())).unwrap_or(0);
-        env.storage().persistent()
-            .set(&DataKey::Pledge(contributor.clone()), &prev.saturating_add(amount));
+        let prev: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Pledge(contributor.clone()))
+            .unwrap_or(0);
+        env.storage().persistent().set(
+            &DataKey::Pledge(contributor.clone()),
+            &prev.saturating_add(amount),
+        );
 
         Self::track_contributor(&env, contributor.clone());
         Self::check_stretch_goals(&env, new_raised);
-        PledgeReceivedEvent { contributor, amount }.publish(&env);
+        PledgeReceivedEvent {
+            contributor,
+            amount,
+        }
+        .publish(&env);
     }
 
     /// Contribute `amount` tokens to the campaign. The caller must have
@@ -290,8 +385,7 @@ impl CrowdfundContract {
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
 
         let contract_addr = env.current_contract_address();
-        token::TokenClient::new(&env, &token_addr)
-            .transfer(&contributor, &contract_addr, &amount);
+        token::TokenClient::new(&env, &token_addr).transfer(&contributor, &contract_addr, &amount);
 
         let new_raised = Self::apply_pledge_with_matching(&env, contributor.clone(), amount);
 
@@ -317,7 +411,11 @@ impl CrowdfundContract {
         let contract_addr = env.current_contract_address();
         token::TokenClient::new(&env, &token_addr).transfer(&sponsor, &contract_addr, &amount);
 
-        let current: i128 = env.storage().persistent().get(&DataKey::MatchingPool).unwrap_or(0);
+        let current: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MatchingPool)
+            .unwrap_or(0);
         env.storage()
             .persistent()
             .set(&DataKey::MatchingPool, &current.saturating_add(amount));
@@ -342,7 +440,11 @@ impl CrowdfundContract {
         env.storage()
             .persistent()
             .set(&DataKey::PledgeComment(contributor.clone()), &comment);
-        PledgeCommentAddedEvent { contributor, comment }.publish(&env);
+        PledgeCommentAddedEvent {
+            contributor,
+            comment,
+        }
+        .publish(&env);
     }
 
     /// Retrieve a contributor's public pledge comment, if any.
@@ -354,7 +456,10 @@ impl CrowdfundContract {
 
     /// Read the currently available sponsor matching pool.
     pub fn matching_pool_balance(env: Env) -> i128 {
-        env.storage().persistent().get(&DataKey::MatchingPool).unwrap_or(0)
+        env.storage()
+            .persistent()
+            .get(&DataKey::MatchingPool)
+            .unwrap_or(0)
     }
 
     /// Withdraw funds to the organizer after deadline if goal was met (#303).
@@ -404,7 +509,11 @@ impl CrowdfundContract {
         }
 
         // Milestone mode: use release_milestone instead.
-        if env.storage().persistent().has(&DataKey::MilestonePercentages) {
+        if env
+            .storage()
+            .persistent()
+            .has(&DataKey::MilestonePercentages)
+        {
             panic_with_error!(&env, CrowdfundError::MilestonesActive);
         }
 
@@ -417,8 +526,7 @@ impl CrowdfundContract {
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
 
         let contract_addr = env.current_contract_address();
-        token::TokenClient::new(&env, &token_addr)
-            .transfer(&contract_addr, &organizer, &raised);
+        token::TokenClient::new(&env, &token_addr).transfer(&contract_addr, &organizer, &raised);
 
         CampaignExecutedEvent { amount: raised }.publish(&env);
     }
@@ -475,52 +583,89 @@ impl CrowdfundContract {
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
 
         let contract_addr = env.current_contract_address();
-        token::TokenClient::new(&env, &token_addr)
-            .transfer(&contract_addr, &contributor, &pledge);
+        token::TokenClient::new(&env, &token_addr).transfer(&contract_addr, &contributor, &pledge);
 
-        RefundClaimedEvent { contributor: contributor.clone(), amount: pledge }.publish(&env);
+        RefundClaimedEvent {
+            contributor: contributor.clone(),
+            amount: pledge,
+        }
+        .publish(&env);
     }
 
     /// Batch refund all contributors after a failed campaign (#307).
     /// Callable by anyone once deadline has passed and goal was not met.
     pub fn batch_refund(env: Env) {
-        let deadline: u64 = env.storage().persistent().get(&DataKey::Deadline)
+        let deadline: u64 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Deadline)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
         if env.ledger().timestamp() <= deadline {
             panic_with_error!(&env, CrowdfundError::CampaignNotEnded);
         }
 
-        let goal: i128 = env.storage().persistent().get(&DataKey::Goal)
+        let goal: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Goal)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
-        let raised: i128 = env.storage().persistent().get(&DataKey::Raised).unwrap_or(0);
-        if raised >= goal { panic_with_error!(&env, CrowdfundError::GoalReached); }
+        let raised: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Raised)
+            .unwrap_or(0);
+        if raised >= goal {
+            panic_with_error!(&env, CrowdfundError::GoalReached);
+        }
 
-        if env.storage().persistent().get(&DataKey::RefundProcessed).unwrap_or(false) {
+        if env
+            .storage()
+            .persistent()
+            .get(&DataKey::RefundProcessed)
+            .unwrap_or(false)
+        {
             panic_with_error!(&env, CrowdfundError::RefundAlreadyProcessed);
         }
-        env.storage().persistent().set(&DataKey::RefundProcessed, &true);
+        env.storage()
+            .persistent()
+            .set(&DataKey::RefundProcessed, &true);
 
-        let token_addr: Address = env.storage().persistent().get(&DataKey::Token)
+        let token_addr: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Token)
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
         let token_client = token::TokenClient::new(&env, &token_addr);
         let contract_addr = env.current_contract_address();
 
-        let contributors: Vec<Address> = env.storage().persistent()
-            .get(&DataKey::Contributors).unwrap_or_else(|| Vec::new(&env));
+        let contributors: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Contributors)
+            .unwrap_or_else(|| Vec::new(&env));
         let count = contributors.len();
         let mut total_refunded: i128 = 0;
 
         for contributor in contributors.iter() {
-            let pledge: i128 = env.storage().persistent()
-                .get(&DataKey::Pledge(contributor.clone())).unwrap_or(0);
+            let pledge: i128 = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Pledge(contributor.clone()))
+                .unwrap_or(0);
             if pledge > 0 {
-                env.storage().persistent().set(&DataKey::Pledge(contributor.clone()), &0_i128);
+                env.storage()
+                    .persistent()
+                    .set(&DataKey::Pledge(contributor.clone()), &0_i128);
                 token_client.transfer(&contract_addr, &contributor, &pledge);
                 total_refunded = total_refunded.saturating_add(pledge);
             }
         }
 
-        BatchRefundProcessedEvent { total_refunded, contributor_count: count }.publish(&env);
+        BatchRefundProcessedEvent {
+            total_refunded,
+            contributor_count: count,
+        }
+        .publish(&env);
     }
 
     /// Add ordered stretch goal milestones (must be in ascending order, all > goal) (#306).
@@ -602,7 +747,9 @@ impl CrowdfundContract {
             prev = tier.min_pledge;
         }
 
-        env.storage().persistent().set(&DataKey::RewardTiers, &tiers);
+        env.storage()
+            .persistent()
+            .set(&DataKey::RewardTiers, &tiers);
     }
 
     /// Select a reward tier. The contributor's total pledge must meet the tier's
@@ -634,7 +781,11 @@ impl CrowdfundContract {
             .persistent()
             .set(&DataKey::SelectedTier(contributor.clone()), &tier_index);
 
-        RewardTierSelectedEvent { contributor, tier_index }.publish(&env);
+        RewardTierSelectedEvent {
+            contributor,
+            tier_index,
+        }
+        .publish(&env);
     }
 
     /// Returns the tier index selected by a contributor, or `None` if none selected.
@@ -663,7 +814,7 @@ impl CrowdfundContract {
             }
             sum = sum.saturating_add(p);
         }
-        if sum != 10_000 || percentages.len() == 0 {
+        if sum != 10_000 || percentages.is_empty() {
             panic_with_error!(&env, CrowdfundError::InvalidMilestonePercentages);
         }
 
@@ -741,7 +892,13 @@ impl CrowdfundContract {
             .set(&tally_key, &current.saturating_add(weight));
         env.storage().persistent().set(&vote_key, &approve);
 
-        MilestoneVoteCastEvent { index, voter, approve, weight }.publish(&env);
+        MilestoneVoteCastEvent {
+            index,
+            voter,
+            approve,
+            weight,
+        }
+        .publish(&env);
     }
 
     /// Release the proportional funds for an unlocked, unreleased milestone to the organizer.
@@ -835,8 +992,7 @@ impl CrowdfundContract {
             .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
 
         let contract_addr = env.current_contract_address();
-        token::TokenClient::new(&env, &token_addr)
-            .transfer(&contract_addr, &organizer, &amount);
+        token::TokenClient::new(&env, &token_addr).transfer(&contract_addr, &organizer, &amount);
 
         MilestoneReleasedEvent { index, amount }.publish(&env);
     }
@@ -847,6 +1003,243 @@ impl CrowdfundContract {
             .persistent()
             .get(&DataKey::Pledge(contributor))
             .unwrap_or(0)
+    }
+
+    // ── Social recovery (#366) ────────────────────────────────────────────────
+
+    /// Configure (or replace) the guardian set and approval threshold used for
+    /// social recovery of the organizer account. Organizer-only. Replacing the
+    /// guardian set while a recovery is pending is rejected to avoid a
+    /// guardian being silently dropped mid-vote.
+    pub fn set_guardians(env: Env, organizer: Address, guardians: Vec<Address>, threshold: u32) {
+        let stored_organizer: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Organizer)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
+
+        if organizer != stored_organizer {
+            panic_with_error!(&env, CrowdfundError::NotInitialized);
+        }
+        organizer.require_auth();
+
+        if env.storage().persistent().has(&DataKey::RecoveryNominee) {
+            panic_with_error!(&env, CrowdfundError::RecoveryAlreadyPending);
+        }
+
+        if threshold == 0 || threshold > guardians.len() {
+            panic_with_error!(&env, CrowdfundError::InvalidThreshold);
+        }
+
+        for i in 0..guardians.len() {
+            let g = guardians.get(i).unwrap();
+            for j in (i + 1)..guardians.len() {
+                if g == guardians.get(j).unwrap() {
+                    panic_with_error!(&env, CrowdfundError::DuplicateGuardian);
+                }
+            }
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::Guardians, &guardians);
+        env.storage()
+            .persistent()
+            .set(&DataKey::GuardianThreshold, &threshold);
+
+        GuardiansSetEvent {
+            organizer,
+            guardian_count: guardians.len(),
+            threshold,
+        }
+        .publish(&env);
+    }
+
+    /// A guardian nominates a new organizer address and casts the first
+    /// approval. Fails if a recovery is already pending. If the threshold is
+    /// 1, this immediately executes the recovery.
+    pub fn initiate_recovery(env: Env, guardian: Address, new_organizer: Address) {
+        guardian.require_auth();
+        Self::require_guardian(&env, &guardian);
+
+        if env.storage().persistent().has(&DataKey::RecoveryNominee) {
+            panic_with_error!(&env, CrowdfundError::RecoveryAlreadyPending);
+        }
+
+        env.storage()
+            .persistent()
+            .set(&DataKey::RecoveryNominee, &new_organizer);
+
+        RecoveryInitiatedEvent {
+            initiator: guardian.clone(),
+            nominee: new_organizer,
+        }
+        .publish(&env);
+
+        Self::record_approval_and_maybe_execute(&env, guardian);
+    }
+
+    /// A guardian approves the pending recovery. Once the configured
+    /// threshold of approvals is reached, the recovery executes immediately
+    /// and the nominee becomes the new organizer.
+    pub fn approve_recovery(env: Env, guardian: Address) {
+        guardian.require_auth();
+        Self::require_guardian(&env, &guardian);
+
+        if !env.storage().persistent().has(&DataKey::RecoveryNominee) {
+            panic_with_error!(&env, CrowdfundError::NoPendingRecovery);
+        }
+
+        Self::record_approval_and_maybe_execute(&env, guardian);
+    }
+
+    fn record_approval_and_maybe_execute(env: &Env, guardian: Address) {
+        let approval_key = DataKey::RecoveryApproval(guardian.clone());
+        if env
+            .storage()
+            .persistent()
+            .get(&approval_key)
+            .unwrap_or(false)
+        {
+            panic_with_error!(env, CrowdfundError::AlreadyApprovedRecovery);
+        }
+        env.storage().persistent().set(&approval_key, &true);
+
+        let threshold: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::GuardianThreshold)
+            .unwrap_or_else(|| panic_with_error!(env, CrowdfundError::GuardiansNotSet));
+
+        let approvals: u32 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RecoveryApprovalCount)
+            .unwrap_or(0)
+            + 1;
+        env.storage()
+            .persistent()
+            .set(&DataKey::RecoveryApprovalCount, &approvals);
+
+        RecoveryApprovedEvent {
+            guardian,
+            approvals,
+            threshold,
+        }
+        .publish(env);
+
+        if approvals >= threshold {
+            let nominee: Address = env
+                .storage()
+                .persistent()
+                .get(&DataKey::RecoveryNominee)
+                .unwrap_or_else(|| panic_with_error!(env, CrowdfundError::NoPendingRecovery));
+            let old_organizer: Address = env
+                .storage()
+                .persistent()
+                .get(&DataKey::Organizer)
+                .unwrap_or_else(|| panic_with_error!(env, CrowdfundError::NotInitialized));
+
+            env.storage()
+                .persistent()
+                .set(&DataKey::Organizer, &nominee);
+
+            Self::clear_pending_recovery(env);
+
+            RecoveryExecutedEvent {
+                old_organizer,
+                new_organizer: nominee,
+            }
+            .publish(env);
+        }
+    }
+
+    /// The current organizer can cancel a pending recovery (e.g. if it was
+    /// not actually compromised). Requires organizer auth so a quorum of
+    /// guardians cannot be silently overridden by anyone else.
+    pub fn cancel_recovery(env: Env, organizer: Address) {
+        let stored_organizer: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Organizer)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NotInitialized));
+
+        if organizer != stored_organizer {
+            panic_with_error!(&env, CrowdfundError::NotInitialized);
+        }
+        organizer.require_auth();
+
+        let nominee: Address = env
+            .storage()
+            .persistent()
+            .get(&DataKey::RecoveryNominee)
+            .unwrap_or_else(|| panic_with_error!(&env, CrowdfundError::NoPendingRecovery));
+
+        Self::clear_pending_recovery(&env);
+
+        RecoveryCancelledEvent { organizer, nominee }.publish(&env);
+    }
+
+    pub fn get_guardians(env: Env) -> Vec<Address> {
+        env.storage()
+            .persistent()
+            .get(&DataKey::Guardians)
+            .unwrap_or_else(|| Vec::new(&env))
+    }
+
+    pub fn get_guardian_threshold(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::GuardianThreshold)
+            .unwrap_or(0)
+    }
+
+    pub fn is_guardian(env: Env, address: Address) -> bool {
+        let guardians: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Guardians)
+            .unwrap_or_else(|| Vec::new(&env));
+        guardians.iter().any(|g| g == address)
+    }
+
+    pub fn get_pending_recovery(env: Env) -> Option<Address> {
+        env.storage().persistent().get(&DataKey::RecoveryNominee)
+    }
+
+    pub fn get_recovery_approval_count(env: Env) -> u32 {
+        env.storage()
+            .persistent()
+            .get(&DataKey::RecoveryApprovalCount)
+            .unwrap_or(0)
+    }
+
+    fn require_guardian(env: &Env, guardian: &Address) {
+        let guardians: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Guardians)
+            .unwrap_or_else(|| panic_with_error!(env, CrowdfundError::GuardiansNotSet));
+        if !guardians.iter().any(|g| &g == guardian) {
+            panic_with_error!(env, CrowdfundError::NotGuardian);
+        }
+    }
+
+    fn clear_pending_recovery(env: &Env) {
+        let guardians: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Guardians)
+            .unwrap_or_else(|| Vec::new(env));
+        for guardian in guardians.iter() {
+            env.storage()
+                .persistent()
+                .remove(&DataKey::RecoveryApproval(guardian));
+        }
+        env.storage().persistent().remove(&DataKey::RecoveryNominee);
+        env.storage()
+            .persistent()
+            .remove(&DataKey::RecoveryApprovalCount);
     }
 
     // ── Read-only accessors ───────────────────────────────────────────────────
@@ -906,13 +1299,20 @@ impl CrowdfundContract {
     /// Emit a `stretch / reached` event for each milestone crossed by `new_raised`
     /// that has not already been triggered.
     fn track_contributor(env: &Env, contributor: Address) {
-        let mut contributors: Vec<Address> = env.storage().persistent()
-            .get(&DataKey::Contributors).unwrap_or_else(|| Vec::new(env));
+        let mut contributors: Vec<Address> = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Contributors)
+            .unwrap_or_else(|| Vec::new(env));
         for c in contributors.iter() {
-            if c == contributor { return; }
+            if c == contributor {
+                return;
+            }
         }
         contributors.push_back(contributor);
-        env.storage().persistent().set(&DataKey::Contributors, &contributors);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Contributors, &contributors);
     }
 
     fn check_stretch_goals(env: &Env, new_raised: i128) {
@@ -944,7 +1344,11 @@ impl CrowdfundContract {
     }
 
     fn apply_pledge_with_matching(env: &Env, contributor: Address, amount: i128) -> i128 {
-        let matching_pool: i128 = env.storage().persistent().get(&DataKey::MatchingPool).unwrap_or(0);
+        let matching_pool: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::MatchingPool)
+            .unwrap_or(0);
         let matched_amount = if matching_pool >= amount {
             amount
         } else {
@@ -963,18 +1367,25 @@ impl CrowdfundContract {
         }
 
         let effective_amount = amount.saturating_add(matched_amount);
-        let raised: i128 = env.storage().persistent().get(&DataKey::Raised).unwrap_or(0);
+        let raised: i128 = env
+            .storage()
+            .persistent()
+            .get(&DataKey::Raised)
+            .unwrap_or(0);
         let new_raised = raised.saturating_add(effective_amount);
-        env.storage().persistent().set(&DataKey::Raised, &new_raised);
+        env.storage()
+            .persistent()
+            .set(&DataKey::Raised, &new_raised);
 
         let prev_pledge: i128 = env
             .storage()
             .persistent()
             .get(&DataKey::Pledge(contributor.clone()))
             .unwrap_or(0);
-        env.storage()
-            .persistent()
-            .set(&DataKey::Pledge(contributor), &prev_pledge.saturating_add(effective_amount));
+        env.storage().persistent().set(
+            &DataKey::Pledge(contributor),
+            &prev_pledge.saturating_add(effective_amount),
+        );
 
         new_raised
     }

--- a/contracts/crowdfund/src/test.rs
+++ b/contracts/crowdfund/src/test.rs
@@ -1,9 +1,16 @@
 use super::*;
 use soroban_sdk::testutils::{Address as _, Ledger as _};
 use soroban_sdk::token::StellarAssetClient;
-use soroban_sdk::{vec, Address, Env};
+use soroban_sdk::{vec, Address, Env, Vec};
 
-fn setup() -> (Env, Address, CrowdfundContractClient<'static>, Address, Address, Address) {
+fn setup() -> (
+    Env,
+    Address,
+    CrowdfundContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let env = Env::default();
     env.mock_all_auths();
     env.ledger().with_mut(|l| l.timestamp = 1_000_000);
@@ -380,8 +387,14 @@ fn test_select_reward_tier_maps_pledge_to_tier() {
 
     client.set_reward_tiers(&soroban_sdk::vec![
         &env,
-        RewardTier { min_pledge: 100, name: soroban_sdk::String::from_str(&env, "Basic") },
-        RewardTier { min_pledge: 500, name: soroban_sdk::String::from_str(&env, "Premium") },
+        RewardTier {
+            min_pledge: 100,
+            name: soroban_sdk::String::from_str(&env, "Basic")
+        },
+        RewardTier {
+            min_pledge: 500,
+            name: soroban_sdk::String::from_str(&env, "Premium")
+        },
     ]);
 
     StellarAssetClient::new(&env, &token).mint(&contributor, &500);
@@ -400,8 +413,14 @@ fn test_select_reward_tier_can_be_updated() {
 
     client.set_reward_tiers(&soroban_sdk::vec![
         &env,
-        RewardTier { min_pledge: 100, name: soroban_sdk::String::from_str(&env, "Basic") },
-        RewardTier { min_pledge: 500, name: soroban_sdk::String::from_str(&env, "Premium") },
+        RewardTier {
+            min_pledge: 100,
+            name: soroban_sdk::String::from_str(&env, "Basic")
+        },
+        RewardTier {
+            min_pledge: 500,
+            name: soroban_sdk::String::from_str(&env, "Premium")
+        },
     ]);
 
     StellarAssetClient::new(&env, &token).mint(&contributor, &600);
@@ -424,7 +443,10 @@ fn test_select_reward_tier_below_minimum_panics() {
 
     client.set_reward_tiers(&soroban_sdk::vec![
         &env,
-        RewardTier { min_pledge: 500, name: soroban_sdk::String::from_str(&env, "Premium") },
+        RewardTier {
+            min_pledge: 500,
+            name: soroban_sdk::String::from_str(&env, "Premium")
+        },
     ]);
 
     StellarAssetClient::new(&env, &token).mint(&contributor, &100);
@@ -443,7 +465,10 @@ fn test_select_invalid_tier_index_panics() {
 
     client.set_reward_tiers(&soroban_sdk::vec![
         &env,
-        RewardTier { min_pledge: 100, name: soroban_sdk::String::from_str(&env, "Basic") },
+        RewardTier {
+            min_pledge: 100,
+            name: soroban_sdk::String::from_str(&env, "Basic")
+        },
     ]);
 
     StellarAssetClient::new(&env, &token).mint(&contributor, &500);
@@ -464,7 +489,14 @@ fn test_get_selected_tier_returns_none_before_selection() {
 
 // ── #311 – Milestone-based fund release ──────────────────────────────────────
 
-fn setup_milestone_campaign() -> (Env, Address, CrowdfundContractClient<'static>, Address, Address, Address) {
+fn setup_milestone_campaign() -> (
+    Env,
+    Address,
+    CrowdfundContractClient<'static>,
+    Address,
+    Address,
+    Address,
+) {
     let (env, contract, client, token, organizer, contributor) = setup();
     let deadline = env.ledger().timestamp() + 86_400;
     client.init_campaign(&organizer, &token, &10_000, &deadline);
@@ -508,7 +540,9 @@ fn setup_governed_milestone_campaign() -> (
 
     env.ledger().with_mut(|l| l.timestamp += 86_401);
 
-    (env, contract, client, token, organizer, voter1, voter2, voter3)
+    (
+        env, contract, client, token, organizer, voter1, voter2, voter3,
+    )
 }
 
 #[test]
@@ -664,8 +698,14 @@ fn milestone_without_majority_cannot_release_funds() {
 fn tiers(env: &Env) -> soroban_sdk::Vec<RewardTier> {
     soroban_sdk::vec![
         env,
-        RewardTier { min_pledge: 200, name: soroban_sdk::String::from_str(env, "Silver") },
-        RewardTier { min_pledge: 1_000, name: soroban_sdk::String::from_str(env, "Gold") },
+        RewardTier {
+            min_pledge: 200,
+            name: soroban_sdk::String::from_str(env, "Silver")
+        },
+        RewardTier {
+            min_pledge: 1_000,
+            name: soroban_sdk::String::from_str(env, "Gold")
+        },
     ]
 }
 
@@ -768,7 +808,9 @@ fn test_non_organizer_cannot_fulfill_reward() {
     let client2 = CrowdfundContractClient::new(&env2, &contract2);
     env2.ledger().with_mut(|l| l.timestamp = 1_000_000);
     let org2 = Address::generate(&env2);
-    let tok2 = env2.register_stellar_asset_contract_v2(org2.clone()).address();
+    let tok2 = env2
+        .register_stellar_asset_contract_v2(org2.clone())
+        .address();
     let con2 = Address::generate(&env2);
     client2.init_campaign(&org2, &tok2, &100, &(env2.ledger().timestamp() + 1_000));
     // No mock_all_auths — calling fulfill_reward as non-organizer must panic.
@@ -955,4 +997,214 @@ fn test_leave_comment_requires_existing_pledge() {
 
     let comment = soroban_sdk::String::from_str(&env, "No pledge yet");
     client.leave_comment(&contributor, &comment);
+}
+
+// ── Social recovery (#366) ──────────────────────────────────────────────────
+
+fn setup_guardians(
+    env: &Env,
+    client: &CrowdfundContractClient<'static>,
+    organizer: &Address,
+    count: u32,
+    threshold: u32,
+) -> Vec<Address> {
+    let mut guardians = Vec::new(env);
+    for _ in 0..count {
+        guardians.push_back(Address::generate(env));
+    }
+    client.set_guardians(organizer, &guardians, &threshold);
+    guardians
+}
+
+#[test]
+fn test_set_guardians_stores_threshold() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &2_000, &deadline);
+
+    let guardians = setup_guardians(&env, &client, &organizer, 3, 2);
+
+    assert_eq!(client.get_guardians(), guardians);
+    assert_eq!(client.get_guardian_threshold(), 2);
+    assert!(client.is_guardian(&guardians.get(0).unwrap()));
+}
+
+#[test]
+#[should_panic]
+fn test_set_guardians_zero_threshold_panics() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &2_000, &deadline);
+    setup_guardians(&env, &client, &organizer, 3, 0);
+}
+
+#[test]
+#[should_panic]
+fn test_set_guardians_threshold_above_count_panics() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &2_000, &deadline);
+    setup_guardians(&env, &client, &organizer, 2, 3);
+}
+
+#[test]
+#[should_panic]
+fn test_set_guardians_duplicate_panics() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &2_000, &deadline);
+
+    let guardian = Address::generate(&env);
+    let guardians = vec![&env, guardian.clone(), guardian];
+    client.set_guardians(&organizer, &guardians, &1);
+}
+
+#[test]
+#[should_panic]
+fn test_non_organizer_cannot_set_guardians() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &2_000, &deadline);
+
+    let not_organizer = Address::generate(&env);
+    let guardians = vec![&env, Address::generate(&env)];
+    client.set_guardians(&not_organizer, &guardians, &1);
+}
+
+#[test]
+fn test_initiate_and_approve_recovery_executes_at_threshold() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &2_000, &deadline);
+    let guardians = setup_guardians(&env, &client, &organizer, 3, 2);
+
+    let new_organizer = Address::generate(&env);
+    client.initiate_recovery(&guardians.get(0).unwrap(), &new_organizer);
+
+    assert_eq!(client.get_pending_recovery(), Some(new_organizer.clone()));
+    assert_eq!(client.get_recovery_approval_count(), 1);
+    // Still the old organizer until threshold is reached.
+    assert_eq!(client.organizer(), organizer);
+
+    client.approve_recovery(&guardians.get(1).unwrap());
+
+    assert_eq!(client.organizer(), new_organizer);
+    assert_eq!(client.get_pending_recovery(), None);
+    assert_eq!(client.get_recovery_approval_count(), 0);
+}
+
+#[test]
+#[should_panic]
+fn test_non_guardian_cannot_initiate_recovery() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &2_000, &deadline);
+    setup_guardians(&env, &client, &organizer, 3, 2);
+
+    let stranger = Address::generate(&env);
+    let new_organizer = Address::generate(&env);
+    client.initiate_recovery(&stranger, &new_organizer);
+}
+
+#[test]
+#[should_panic]
+fn test_initiate_recovery_without_guardians_panics() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &2_000, &deadline);
+
+    let stranger = Address::generate(&env);
+    let new_organizer = Address::generate(&env);
+    client.initiate_recovery(&stranger, &new_organizer);
+}
+
+#[test]
+#[should_panic]
+fn test_double_initiate_recovery_panics() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &2_000, &deadline);
+    let guardians = setup_guardians(&env, &client, &organizer, 3, 2);
+
+    let new_organizer_a = Address::generate(&env);
+    let new_organizer_b = Address::generate(&env);
+    client.initiate_recovery(&guardians.get(0).unwrap(), &new_organizer_a);
+    client.initiate_recovery(&guardians.get(1).unwrap(), &new_organizer_b);
+}
+
+#[test]
+#[should_panic]
+fn test_guardian_cannot_approve_twice() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &2_000, &deadline);
+    let guardians = setup_guardians(&env, &client, &organizer, 3, 3);
+
+    let new_organizer = Address::generate(&env);
+    client.initiate_recovery(&guardians.get(0).unwrap(), &new_organizer);
+    client.approve_recovery(&guardians.get(0).unwrap());
+}
+
+#[test]
+#[should_panic]
+fn test_approve_recovery_without_pending_panics() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &2_000, &deadline);
+    let guardians = setup_guardians(&env, &client, &organizer, 3, 2);
+
+    client.approve_recovery(&guardians.get(0).unwrap());
+}
+
+#[test]
+fn test_organizer_can_cancel_pending_recovery() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &2_000, &deadline);
+    let guardians = setup_guardians(&env, &client, &organizer, 3, 2);
+
+    let new_organizer = Address::generate(&env);
+    client.initiate_recovery(&guardians.get(0).unwrap(), &new_organizer);
+    client.cancel_recovery(&organizer);
+
+    assert_eq!(client.get_pending_recovery(), None);
+    assert_eq!(client.organizer(), organizer);
+
+    // Guardian can re-initiate after cancellation.
+    client.initiate_recovery(&guardians.get(1).unwrap(), &new_organizer);
+    assert_eq!(client.get_pending_recovery(), Some(new_organizer));
+}
+
+#[test]
+#[should_panic]
+fn test_non_organizer_cannot_cancel_recovery() {
+    let (env, _contract, client, token, organizer, _) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &2_000, &deadline);
+    let guardians = setup_guardians(&env, &client, &organizer, 3, 2);
+
+    let new_organizer = Address::generate(&env);
+    client.initiate_recovery(&guardians.get(0).unwrap(), &new_organizer);
+
+    let stranger = Address::generate(&env);
+    client.cancel_recovery(&stranger);
+}
+
+#[test]
+fn test_recovered_organizer_can_execute_campaign() {
+    let (env, _contract, client, token, organizer, _contributor) = setup();
+    let deadline = env.ledger().timestamp() + 86_400;
+    client.init_campaign(&organizer, &token, &2_000, &deadline);
+    let guardians = setup_guardians(&env, &client, &organizer, 3, 1);
+
+    StellarAssetClient::new(&env, &token).mint(&organizer, &2_000);
+    client.contribute(&organizer, &2_000);
+
+    let new_organizer = Address::generate(&env);
+    client.initiate_recovery(&guardians.get(0).unwrap(), &new_organizer);
+
+    env.ledger().with_mut(|l| l.timestamp = deadline + 1);
+    client.execute_campaign();
+
+    assert_eq!(client.organizer(), new_organizer);
 }


### PR DESCRIPTION
## Summary
- Adds guardian-based social recovery to `crowdfund` so a campaign organizer's account can be recovered if compromised or lost.
- `set_guardians`: organizer configures (or replaces) the guardian set and approval threshold (rejects if a recovery is currently pending, validates threshold bounds and duplicate guardians).
- `initiate_recovery`: any guardian nominates a replacement organizer and casts the first approval; auto-executes immediately if threshold is 1.
- `approve_recovery`: additional guardians approve; once approvals reach the threshold, the organizer is swapped atomically and all pending-recovery state is cleared (rent-efficient — no stale per-guardian flags left behind).
- `cancel_recovery`: current organizer can cancel a pending recovery (e.g. false alarm), requiring organizer auth so it can't be hijacked by a non-organizer.
- Events: `GuardiansSetEvent`, `RecoveryInitiatedEvent`, `RecoveryApprovedEvent`, `RecoveryExecutedEvent`, `RecoveryCancelledEvent`.
- Read-only accessors: `get_guardians`, `get_guardian_threshold`, `is_guardian`, `get_pending_recovery`, `get_recovery_approval_count`.
- Fully backward compatible: feature is opt-in via `set_guardians`; existing flows (`pledge`, `contribute`, `execute_campaign`, etc.) are untouched.
- Fixes a pre-existing compile error (`PledgeReceivedEvent` missing `#[contractevent]`) and two clippy lints in this package, required to get `cargo test -p crowdfund` green under `-D warnings`.

## Test plan
- [x] `cargo fmt -p crowdfund -- --check`
- [x] `cargo clippy -p crowdfund --all-targets -- -D warnings`
- [x] `cargo test -p crowdfund` — 72 tests passing, including happy path, unauthorized/non-guardian access, duplicate-approval, threshold-not-met, cancel-then-reinitiate, and full lifecycle (organizer recovered then exercises `execute_campaign`) for the new recovery flow

Closes #366