### PR TITLE
# Add campaign secondary sale royalty logic

### DIFF
--- a/contracts/shade/src/components/campaign_royalties.rs
+++ b/contracts/shade/src/components/campaign_royalties.rs
@@ -104,6 +104,9 @@ pub fn execute_secondary_sale(
     if config.royalty_bps > MAX_BPS {
         panic_with_error!(env, ContractError::InvalidRoyaltyBps);
     }
+    if config.merchant_id != campaign.merchant_id || config.token != *token {
+        panic_with_error!(env, ContractError::NotAuthorized);
+    }
 
     let royalty_amount = bps_of(gross_amount, config.royalty_bps)
         .unwrap_or_else(|| panic_with_error!(env, ContractError::InvalidAmount));

--- a/contracts/shade/src/components/campaign_royalties.rs
+++ b/contracts/shade/src/components/campaign_royalties.rs
@@ -1,0 +1,224 @@
+use crate::components::{admin, campaigns};
+use crate::errors::ContractError;
+use crate::events;
+use crate::types::{CampaignRoyaltyConfig, CampaignSecondarySale, DataKey};
+use soroban_sdk::{panic_with_error, token, Address, Env, Option};
+
+const MAX_BPS: u32 = 10_000;
+
+pub fn set_campaign_royalty(
+    env: &Env,
+    merchant: &Address,
+    campaign_id: u64,
+    royalty_bps: u32,
+    recipient: Option<Address>,
+) {
+    merchant.require_auth();
+
+    if royalty_bps > MAX_BPS {
+        panic_with_error!(env, ContractError::InvalidRoyaltyBps);
+    }
+
+    let campaign = campaigns::get_campaign(env, campaign_id);
+    if campaign.merchant != *merchant {
+        panic_with_error!(env, ContractError::NotCampaignMerchant);
+    }
+
+    if !admin::is_accepted_token(env, &campaign.token) {
+        panic_with_error!(env, ContractError::TokenNotAccepted);
+    }
+
+    let royalty_recipient = recipient.unwrap_or_else(|| campaign.merchant.clone());
+    let config = CampaignRoyaltyConfig {
+        campaign_id,
+        merchant_id: campaign.merchant_id,
+        recipient: royalty_recipient.clone(),
+        token: campaign.token.clone(),
+        royalty_bps,
+        updated_at: env.ledger().timestamp(),
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::CampaignRoyaltyConfig(campaign_id), &config);
+
+    events::publish_campaign_royalty_configured_event(
+        env,
+        campaign_id,
+        campaign.merchant_id,
+        merchant.clone(),
+        royalty_recipient,
+        campaign.token,
+        royalty_bps,
+        env.ledger().timestamp(),
+    );
+}
+
+pub fn get_campaign_royalty_config(
+    env: &Env,
+    campaign_id: u64,
+) -> Option<CampaignRoyaltyConfig> {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CampaignRoyaltyConfig(campaign_id))
+}
+
+pub fn execute_secondary_sale(
+    env: &Env,
+    seller: &Address,
+    buyer: &Address,
+    campaign_id: u64,
+    token: &Address,
+    gross_amount: i128,
+) -> u64 {
+    seller.require_auth();
+    buyer.require_auth();
+
+    if seller == buyer {
+        panic_with_error!(env, ContractError::NotAuthorized);
+    }
+    if gross_amount <= 0 {
+        panic_with_error!(env, ContractError::InvalidResalePrice);
+    }
+
+    let campaign = campaigns::get_campaign(env, campaign_id);
+    if !campaign.active {
+        panic_with_error!(env, ContractError::CampaignInactive);
+    }
+    if campaign.token != *token {
+        panic_with_error!(env, ContractError::TokenNotAccepted);
+    }
+    if !admin::is_accepted_token(env, token) {
+        panic_with_error!(env, ContractError::TokenNotAccepted);
+    }
+
+    let config = get_campaign_royalty_config(env, campaign_id).unwrap_or(CampaignRoyaltyConfig {
+        campaign_id,
+        merchant_id: campaign.merchant_id,
+        recipient: campaign.merchant.clone(),
+        token: campaign.token.clone(),
+        royalty_bps: 0,
+        updated_at: campaign.created_at,
+    });
+
+    if config.royalty_bps > MAX_BPS {
+        panic_with_error!(env, ContractError::InvalidRoyaltyBps);
+    }
+
+    let royalty_amount = bps_of(gross_amount, config.royalty_bps)
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::InvalidAmount));
+    if royalty_amount < 0 || royalty_amount > gross_amount {
+        panic_with_error!(env, ContractError::InvalidAmount);
+    }
+    let seller_amount = gross_amount - royalty_amount;
+
+    let token_client = token::TokenClient::new(env, token);
+    if seller_amount > 0 {
+        token_client.transfer(buyer, seller, &seller_amount);
+    }
+    if royalty_amount > 0 {
+        token_client.transfer(buyer, &config.recipient, &royalty_amount);
+    }
+
+    let sale_id = get_sale_count(env) + 1;
+    let sale = CampaignSecondarySale {
+        sale_id,
+        campaign_id,
+        merchant_id: campaign.merchant_id,
+        seller: seller.clone(),
+        buyer: buyer.clone(),
+        token: token.clone(),
+        gross_amount,
+        royalty_amount,
+        seller_amount,
+        royalty_bps: config.royalty_bps,
+        royalty_recipient: config.recipient.clone(),
+        timestamp: env.ledger().timestamp(),
+    };
+
+    env.storage()
+        .persistent()
+        .set(&DataKey::CampaignSecondarySale(sale_id), &sale);
+    env.storage()
+        .persistent()
+        .set(&DataKey::CampaignSecondarySaleCount, &sale_id);
+
+    let total: i128 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::CampaignRoyaltyEarnings(campaign_id))
+        .unwrap_or(0);
+    env.storage().persistent().set(
+        &DataKey::CampaignRoyaltyEarnings(campaign_id),
+        &(total.saturating_add(royalty_amount)),
+    );
+
+    let token_total: i128 = env
+        .storage()
+        .persistent()
+        .get(&DataKey::CampaignRoyaltyEarningsByToken(campaign_id, token.clone()))
+        .unwrap_or(0);
+    env.storage().persistent().set(
+        &DataKey::CampaignRoyaltyEarningsByToken(campaign_id, token.clone()),
+        &(token_total.saturating_add(royalty_amount)),
+    );
+
+    events::publish_campaign_secondary_sale_event(
+        env,
+        sale_id,
+        campaign_id,
+        campaign.merchant_id,
+        seller.clone(),
+        buyer.clone(),
+        token.clone(),
+        gross_amount,
+        royalty_amount,
+        seller_amount,
+        config.royalty_bps,
+        config.recipient,
+        env.ledger().timestamp(),
+    );
+
+    sale_id
+}
+
+pub fn get_campaign_secondary_sale(env: &Env, sale_id: u64) -> CampaignSecondarySale {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CampaignSecondarySale(sale_id))
+        .unwrap_or_else(|| panic_with_error!(env, ContractError::NotFound))
+}
+
+pub fn get_campaign_secondary_sale_count(env: &Env) -> u64 {
+    get_sale_count(env)
+}
+
+pub fn get_campaign_royalty_earnings(env: &Env, campaign_id: u64) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CampaignRoyaltyEarnings(campaign_id))
+        .unwrap_or(0)
+}
+
+pub fn get_campaign_royalty_earnings_for_token(
+    env: &Env,
+    campaign_id: u64,
+    token: &Address,
+) -> i128 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CampaignRoyaltyEarningsByToken(campaign_id, token.clone()))
+        .unwrap_or(0)
+}
+
+fn get_sale_count(env: &Env) -> u64 {
+    env.storage()
+        .persistent()
+        .get(&DataKey::CampaignSecondarySaleCount)
+        .unwrap_or(0)
+}
+
+fn bps_of(value: i128, bps: u32) -> Option<i128> {
+    let scaled = value.checked_mul(i128::from(bps))?;
+    Some(scaled / i128::from(MAX_BPS))
+}

--- a/contracts/shade/src/components/mod.rs
+++ b/contracts/shade/src/components/mod.rs
@@ -4,6 +4,7 @@ pub mod admin;
 // pub mod auto_withdrawal; // TODO: references missing types/events — disabled for compilation
 pub mod auto_withdrawal;
 pub mod campaigns;
+pub mod campaign_royalties;
 pub mod bridge;
 pub mod core;
 pub mod event;

--- a/contracts/shade/src/events.rs
+++ b/contracts/shade/src/events.rs
@@ -1677,6 +1677,10 @@ pub fn publish_campaign_updated_event(
         title,
         description,
         timestamp,
+    }
+    .publish(env);
+}
+
 /// Emitted each time a registered signer approves a proposal.
 #[contractevent]
 pub struct WithdrawalApprovedEvent {
@@ -1703,6 +1707,11 @@ pub fn publish_withdrawal_approved_event(
         signer,
         approvals_so_far,
         quorum_required,
+        timestamp,
+    }
+    .publish(env);
+}
+
 #[contractevent]
 pub struct AutoWithdrawalTriggeredEvent {
     pub merchant_id: u64,
@@ -1770,6 +1779,10 @@ pub fn publish_campaign_tag_added_event(
         campaign_id,
         merchant,
         tag_id,
+        timestamp,
+    }
+    .publish(env);
+}
 // ── Escrow expired-refund event ────────────────────────────────────────────────
 
 /// Emitted when a subscription plan query is executed.
@@ -1843,6 +1856,11 @@ pub fn publish_campaign_contribution_event(
         amount,
         raised_amount,
         goal_amount,
+        timestamp,
+    }
+    .publish(env);
+}
+
 /// Emitted when an event (ticketing) query is executed.
 #[contractevent]
 pub struct EventSearchExecutedEvent {
@@ -1860,6 +1878,11 @@ pub fn publish_event_search_executed_event(
     EventSearchExecutedEvent {
         caller,
         result_count,
+        timestamp,
+    }
+    .publish(env);
+}
+
 #[contractevent]
 pub struct EscrowExpiredRefundEvent {
     pub invoice_id: u64,

--- a/contracts/shade/src/events.rs
+++ b/contracts/shade/src/events.rs
@@ -1886,3 +1886,86 @@ pub fn publish_escrow_expired_refund_event(
     }
     .publish(env);
 }
+
+#[contractevent]
+pub struct CampaignRoyaltyConfiguredEvent {
+    pub campaign_id: u64,
+    pub merchant_id: u64,
+    pub merchant: Address,
+    pub recipient: Address,
+    pub token: Address,
+    pub royalty_bps: u32,
+    pub timestamp: u64,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn publish_campaign_royalty_configured_event(
+    env: &Env,
+    campaign_id: u64,
+    merchant_id: u64,
+    merchant: Address,
+    recipient: Address,
+    token: Address,
+    royalty_bps: u32,
+    timestamp: u64,
+) {
+    CampaignRoyaltyConfiguredEvent {
+        campaign_id,
+        merchant_id,
+        merchant,
+        recipient,
+        token,
+        royalty_bps,
+        timestamp,
+    }
+    .publish(env);
+}
+
+#[contractevent]
+pub struct CampaignSecondarySaleEvent {
+    pub sale_id: u64,
+    pub campaign_id: u64,
+    pub merchant_id: u64,
+    pub seller: Address,
+    pub buyer: Address,
+    pub token: Address,
+    pub gross_amount: i128,
+    pub royalty_amount: i128,
+    pub seller_amount: i128,
+    pub royalty_bps: u32,
+    pub royalty_recipient: Address,
+    pub timestamp: u64,
+}
+
+#[allow(clippy::too_many_arguments)]
+pub fn publish_campaign_secondary_sale_event(
+    env: &Env,
+    sale_id: u64,
+    campaign_id: u64,
+    merchant_id: u64,
+    seller: Address,
+    buyer: Address,
+    token: Address,
+    gross_amount: i128,
+    royalty_amount: i128,
+    seller_amount: i128,
+    royalty_bps: u32,
+    royalty_recipient: Address,
+    timestamp: u64,
+) {
+    CampaignSecondarySaleEvent {
+        sale_id,
+        campaign_id,
+        merchant_id,
+        seller,
+        buyer,
+        token,
+        gross_amount,
+        royalty_amount,
+        seller_amount,
+        royalty_bps,
+        royalty_recipient,
+        timestamp,
+    }
+    .publish(env);
+}

--- a/contracts/shade/src/shade.rs
+++ b/contracts/shade/src/shade.rs
@@ -1373,7 +1373,7 @@ impl ShadeTrait for Shade {
         campaign_royalties_component::get_campaign_secondary_sale(&env, sale_id)
     }
 
-    fn get_campaign_secondary_sale_count(env: Env) -> u64 {
+    fn get_campaign_sale_count(env: Env) -> u64 {
         campaign_royalties_component::get_campaign_secondary_sale_count(&env)
     }
 
@@ -1381,7 +1381,7 @@ impl ShadeTrait for Shade {
         campaign_royalties_component::get_campaign_royalty_earnings(&env, campaign_id)
     }
 
-    fn get_campaign_royalty_earnings_for_token(
+    fn get_campaign_token_royalties(
         env: Env,
         campaign_id: u64,
         token: Address,

--- a/contracts/shade/src/shade.rs
+++ b/contracts/shade/src/shade.rs
@@ -1,4 +1,5 @@
 ﻿use crate::components::{
+    campaign_royalties as campaign_royalties_component,
     nft as nft_component,
     access_control as access_control_component, admin as admin_component, core as core_component,
     invoice as invoice_component, merchant as merchant_component,
@@ -27,7 +28,7 @@ use crate::types::{
     OracleConfig, PaymentPayload, PendingFee, Role, Subscription, SubscriptionPlan, Ticket,
     TokenAnalytics, Transaction,
 };
-use soroban_sdk::{contract, contractimpl, panic_with_error, Address, BytesN, Env, String, Vec};
+use soroban_sdk::{contract, contractimpl, panic_with_error, Address, BytesN, Env, Option, String, Vec};
 
 #[contract]
 pub struct Shade;
@@ -1320,6 +1321,76 @@ impl ShadeTrait for Shade {
 
     fn get_top_donors(env: Env, campaign_id: u64) -> Vec<DonorInfo> {
         leaderboard_component::get_top_donors(&env, campaign_id)
+    }
+
+    fn set_campaign_royalty(
+        env: Env,
+        merchant: Address,
+        campaign_id: u64,
+        royalty_bps: u32,
+        recipient: Option<Address>,
+    ) {
+        pausable_component::assert_not_paused(&env);
+        campaign_royalties_component::set_campaign_royalty(
+            &env,
+            &merchant,
+            campaign_id,
+            royalty_bps,
+            recipient,
+        );
+    }
+
+    fn get_campaign_royalty_config(
+        env: Env,
+        campaign_id: u64,
+    ) -> Option<crate::types::CampaignRoyaltyConfig> {
+        campaign_royalties_component::get_campaign_royalty_config(&env, campaign_id)
+    }
+
+    fn execute_campaign_secondary_sale(
+        env: Env,
+        seller: Address,
+        buyer: Address,
+        campaign_id: u64,
+        token: Address,
+        gross_amount: i128,
+    ) -> u64 {
+        pausable_component::assert_not_paused(&env);
+        campaign_royalties_component::execute_secondary_sale(
+            &env,
+            &seller,
+            &buyer,
+            campaign_id,
+            &token,
+            gross_amount,
+        )
+    }
+
+    fn get_campaign_secondary_sale(
+        env: Env,
+        sale_id: u64,
+    ) -> crate::types::CampaignSecondarySale {
+        campaign_royalties_component::get_campaign_secondary_sale(&env, sale_id)
+    }
+
+    fn get_campaign_secondary_sale_count(env: Env) -> u64 {
+        campaign_royalties_component::get_campaign_secondary_sale_count(&env)
+    }
+
+    fn get_campaign_royalty_earnings(env: Env, campaign_id: u64) -> i128 {
+        campaign_royalties_component::get_campaign_royalty_earnings(&env, campaign_id)
+    }
+
+    fn get_campaign_royalty_earnings_for_token(
+        env: Env,
+        campaign_id: u64,
+        token: Address,
+    ) -> i128 {
+        campaign_royalties_component::get_campaign_royalty_earnings_for_token(
+            &env,
+            campaign_id,
+            &token,
+        )
     }
 }
 

--- a/contracts/shade/src/shade_interface.rs
+++ b/contracts/shade/src/shade_interface.rs
@@ -248,9 +248,9 @@ pub trait ShadeTrait {
         gross_amount: i128,
     ) -> u64;
     fn get_campaign_secondary_sale(env: Env, sale_id: u64) -> CampaignSecondarySale;
-    fn get_campaign_secondary_sale_count(env: Env) -> u64;
+    fn get_campaign_sale_count(env: Env) -> u64;
     fn get_campaign_royalty_earnings(env: Env, campaign_id: u64) -> i128;
-    fn get_campaign_royalty_earnings_for_token(
+    fn get_campaign_token_royalties(
         env: Env,
         campaign_id: u64,
         token: Address,

--- a/contracts/shade/src/shade_interface.rs
+++ b/contracts/shade/src/shade_interface.rs
@@ -1,10 +1,10 @@
 use crate::types::{
-    Campaign, CampaignAffiliate, CampaignParticipant, CrossChainBridgePayload, Event, Invoice,
-    InvoiceFilter, Merchant, MerchantAnalytics, MerchantAnalyticsSummary, MerchantFilter,
-    OracleConfig, PaymentPayload, PendingFee, Role, Subscription, SubscriptionPlan, Ticket,
-    TokenAnalytics, Transaction,
+    Campaign, CampaignAffiliate, CampaignParticipant, CampaignRoyaltyConfig,
+    CampaignSecondarySale, CrossChainBridgePayload, Event, Invoice, InvoiceFilter, Merchant,
+    MerchantAnalytics, MerchantAnalyticsSummary, MerchantFilter, OracleConfig, PaymentPayload,
+    PendingFee, Role, Subscription, SubscriptionPlan, Ticket, TokenAnalytics, Transaction,
 };
-use soroban_sdk::{contracttrait, Address, BytesN, Env, String, Vec};
+use soroban_sdk::{contracttrait, Address, BytesN, Env, Option, String, Vec};
 
 #[contracttrait]
 pub trait ShadeTrait {
@@ -227,4 +227,32 @@ pub trait ShadeTrait {
     fn get_campaign_participant(env: Env, campaign_id: u64, participant: Address) -> CampaignParticipant;
     fn get_campaign_affiliate(env: Env, campaign_id: u64, affiliate: Address) -> CampaignAffiliate;
     fn get_campaign_leaderboard(env: Env, campaign_id: u64, limit: u32) -> Vec<(Address, i128)>;
+
+    fn set_campaign_royalty(
+        env: Env,
+        merchant: Address,
+        campaign_id: u64,
+        royalty_bps: u32,
+        recipient: Option<Address>,
+    );
+    fn get_campaign_royalty_config(
+        env: Env,
+        campaign_id: u64,
+    ) -> Option<CampaignRoyaltyConfig>;
+    fn execute_campaign_secondary_sale(
+        env: Env,
+        seller: Address,
+        buyer: Address,
+        campaign_id: u64,
+        token: Address,
+        gross_amount: i128,
+    ) -> u64;
+    fn get_campaign_secondary_sale(env: Env, sale_id: u64) -> CampaignSecondarySale;
+    fn get_campaign_secondary_sale_count(env: Env) -> u64;
+    fn get_campaign_royalty_earnings(env: Env, campaign_id: u64) -> i128;
+    fn get_campaign_royalty_earnings_for_token(
+        env: Env,
+        campaign_id: u64,
+        token: Address,
+    ) -> i128;
 }

--- a/contracts/shade/src/types.rs
+++ b/contracts/shade/src/types.rs
@@ -78,6 +78,16 @@ pub enum DataKey {
     MerchantCampaigns(u64),
     /// Reverse index: campaign_id -> ordered list of attached tag IDs.
     CampaignTagList(u64),
+    /// Per-campaign secondary-sale royalty configuration.
+    CampaignRoyaltyConfig(u64),
+    /// Sequential secondary-sale ledger entry.
+    CampaignSecondarySale(u64),
+    /// Total number of campaign secondary sales ever recorded.
+    CampaignSecondarySaleCount,
+    /// Cumulative royalties earned by a campaign across all tokens.
+    CampaignRoyaltyEarnings(u64),
+    /// Cumulative royalties earned by a campaign for a specific token.
+    CampaignRoyaltyEarningsByToken(u64, Address),
     // --- Cross-chain pledge system ---
     CrossChainPledge(u64),
     CrossChainPledgeCount,
@@ -587,6 +597,34 @@ pub struct CampaignTag {
     pub id: u64,
     pub name: String,
     pub creator: Address,
+    pub timestamp: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CampaignRoyaltyConfig {
+    pub campaign_id: u64,
+    pub merchant_id: u64,
+    pub recipient: Address,
+    pub token: Address,
+    pub royalty_bps: u32,
+    pub updated_at: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct CampaignSecondarySale {
+    pub sale_id: u64,
+    pub campaign_id: u64,
+    pub merchant_id: u64,
+    pub seller: Address,
+    pub buyer: Address,
+    pub token: Address,
+    pub gross_amount: i128,
+    pub royalty_amount: i128,
+    pub seller_amount: i128,
+    pub royalty_bps: u32,
+    pub royalty_recipient: Address,
     pub timestamp: u64,
 }
 

--- a/contracts/shade/src/types.rs
+++ b/contracts/shade/src/types.rs
@@ -765,6 +765,8 @@ pub struct InvoicePage {
 pub struct MerchantPage {
     pub items: soroban_sdk::Vec<Merchant>,
     pub page_info: PageInfo,
+}
+
 // --- Campaign fundraising engine ---
 #[contracttype]
 #[derive(Clone, Debug, Eq, PartialEq)]


### PR DESCRIPTION
Closes #347

## Summary
- add per-campaign royalty configuration for secondary campaign sales
- execute authenticated buyer/seller secondary sales with royalty routing to the configured recipient
- persist compact secondary sale records plus cumulative campaign royalty earnings
- expose VM entrypoints for royalty config, sale execution, sale lookup, sale count, and earnings queries
- emit detailed royalty configuration and secondary sale events for off-chain indexing

## Verification
- git diff --check: passed

